### PR TITLE
Misc fixes to frontend build script

### DIFF
--- a/scripts/inject_frontend.sh
+++ b/scripts/inject_frontend.sh
@@ -1,7 +1,7 @@
 # run to inject static assets into code
 # bash ./inject_frontend.sh
 
-cd Sources/Server/Frontend
+cd "$(dirname "$0")/../Sources/Server/Frontend" || exit
 
 npm install
 npm run build


### PR DESCRIPTION
Hello. This PR makes 2 improvements to the frontend build script:

1. Adds a `npm install` step to install dependencies like `rollup` so that the build won't fail if a user hasn't already done that manually.
2. `cd`s to the correct directory regardless of how the user has run the script. For example, with this change, you can now run the script from the root of the repo with `./scripts/inject_frontend.sh` and the `cd` will go to the correct directory.

This should make building from source a bit more straightforward, as noted in https://github.com/cooklang/CookCLI/issues/4 and https://github.com/cooklang/CookCLI/issues/11.