### PR TITLE
Fix url typo in command abstract

### DIFF
--- a/Sources/CookCLI/Commands/Recipe.swift
+++ b/Sources/CookCLI/Commands/Recipe.swift
@@ -93,7 +93,7 @@ extension Cook {
             var file: String
 
             // MARK: ParsableCommand
-            static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Download a random image from upsplash.com to match the recipe title")
+            static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Download a random image from unsplash.com to match the recipe title")
 
             func run() throws {
                  let fileUrl = URL(fileURLWithPath: file)


### PR DESCRIPTION
The command description had the wrong url. u**p**splash instead of u**n**splash.