### PR TITLE
Implement output in markdown format

### DIFF
--- a/Sources/CookCLI/Commands/Recipe.swift
+++ b/Sources/CookCLI/Commands/Recipe.swift
@@ -21,7 +21,7 @@ extension Cook {
             // MARK: ParsableCommand
             static var configuration: CommandConfiguration = CommandConfiguration(abstract: "Parse and print a CookLang recipe file")
 
-            @Option(help: "Set the output format to json or yaml")
+            @Option(help: "Set the output format to json, yaml, or markdown")
             var outputFormat: OutputFormat = .text
 
             @Flag(help: "Print only the ingredients section of the output")

--- a/Sources/CookCLI/CookCLI.swift
+++ b/Sources/CookCLI/CookCLI.swift
@@ -33,7 +33,7 @@ func readSTDIN () -> String? {
 }
 
 enum OutputFormat: String, ExpressibleByArgument {
-    case text, json, yaml
+    case text, json, yaml, markdown
 }
 
 struct Cook: ParsableCommand {    

--- a/Sources/CookCLI/Printable/CookRecipe+Printable.swift
+++ b/Sources/CookCLI/Printable/CookRecipe+Printable.swift
@@ -20,6 +20,8 @@ extension CookRecipe {
         switch outputFormat {
         case .text:
             printText(onlyIngredients: onlyIngredients)
+        case .markdown:
+            try printMarkdown()
         case .json:
             try printJson()
         case .yaml:
@@ -29,6 +31,42 @@ extension CookRecipe {
 
     private func printText(onlyIngredients: Bool) {
         Swift.print(printableLines(onlyIngredients: onlyIngredients).map { line in
+            return line.description
+        }.joined(separator: .newLine))
+    }
+
+    private func printMarkdown() throws {
+        var lines: [PrintableLine] = []
+
+        if (!metadata.isEmpty) {
+            let frontMatter = try YAMLEncoder().encode(metadata)
+            lines.append(.text("---"))
+            lines.append(.text(frontMatter))
+            lines.append(.text("---"))
+            lines.append(.empty)
+        }
+
+        lines.append(.text("## Ingredients"))
+        for (name, amounts) in ingredientsTable.ingredients {
+           lines.append(.text("- \(amounts) \(name)"))
+        }
+
+        lines.append(.empty)
+
+        if (!cookware.isEmpty) {
+            lines.append(.text("## Cookware"))
+            cookware.forEach { e in
+                lines.append(.text("- \(e)"))
+            }
+            lines.append(.empty)
+        }
+
+        lines.append(.text("## Steps"))
+        for (index, step) in steps.enumerated() {
+            lines.append(.step(step, index))
+        }
+
+        Swift.print(lines.map { line in
             return line.description
         }.joined(separator: .newLine))
     }

--- a/Sources/CookCLI/Printable/CookShoppingList+Printable.swift
+++ b/Sources/CookCLI/Printable/CookShoppingList+Printable.swift
@@ -20,6 +20,8 @@ extension CookShoppingList {
         switch outputFormat {
         case .text:
             printText(onlyIngredients: onlyIngredients)
+        case .markdown:
+            Swift.print("not implemented yet")
         case .json:
             try printJson()
         case .yaml:


### PR DESCRIPTION
Quick and dirty implementation to print recipes in Markdown format with ATX-style headers.

Implements suggestion #32 