### PR TITLE
Port to other POSIX platforms like Android and BSD

### DIFF
--- a/Sources/CookCLI/CookCLI.swift
+++ b/Sources/CookCLI/CookCLI.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import ArgumentParser
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
 #else
     import Darwin


### PR DESCRIPTION
This was [the only change I had to make to this repo when I packaged it for Android recently](https://github.com/termux/termux-packages/pull/11081/files#diff-6cdf19876c9ce0130acc7ae23e2a8e8347bf7e33c9f39e22fcd5cef5a45eea1cR10), though your dependencies required further patching.

I was happily surprised to find that `cook server` just worked on an Android tablet I then tried it on, nice work. 😄