### PR TITLE
Fix Docker build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ swift build --configuration release -static-executable
 Note. If you don't want to install Swift, there's a `Dockerfile` for building Linux binary:
 
     docker build -t cook-builder .
-    docker run  --volume $(CURRENT_PATH):/src --workdir /src --entrypoint "swift" -it cook-builder build --configuration release -Xswiftc -static-executable
+    docker run  --volume $(pwd):/src --workdir /src --entrypoint "swift" -it cook-builder build --configuration release -Xswiftc -static-executable
 
 
 ## Contribution


### PR DESCRIPTION
The Docker build instructions didn't work because Ubuntu 21.10 is discontinued.
There was also nothing in the instructions about CURRENT_PATH variable, so I replaced it with a conventional way to get current path.