### PR TITLE
Allow mobile to only take up 100% width of viewport

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -67,7 +67,8 @@
 
 <style>
     .viewport {
-        width: 800px;
+        width: 100%;
+        max-width: 800px;
         margin: 50px auto;
     }
 </style>


### PR DESCRIPTION
This tiny change modifies the way the viewport behaves on screens smaller than 800px in width. Instead of keeping the 800px minimum, this allows smaller screens to adjust the viewport to a smaller width, making reading recipes on mobile much easier.