### PR TITLE
Add docker files to automatically build and run the webserver

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,2 @@
+# The directory where data and configuration will be stored.
+ROOT=/home/ubuntu/recipes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+# Use the official Rust image as the base
+FROM rust:latest
+
+# Install Node.js (latest version)
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs
+
+# Set the working directory in the container
+WORKDIR /usr/src/cookcli
+
+# Clone the cookcli repository
+RUN git clone https://github.com/cooklang/cookcli.git .
+
+# Install any JavaScript dependencies (if applicable)
+WORKDIR /usr/src/cookcli/ui
+RUN npm install && npm run build
+
+# Build the project (both Rust and Node dependencies)
+WORKDIR /usr/src/cookcli/src
+RUN cargo build --release
+
+# Add the cook binary to the PATH
+ENV PATH="/usr/src/cookcli/target/release:${PATH}"
+
+# Expose port 9080 for the web server
+EXPOSE 9080
+
+# Switch to the /recipes directory
+WORKDIR /recipes
+
+# Run the cook server with --host
+CMD ["cook", "server", "--host"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+To build the latest version of Cooklang webserver:      
+
+```
+docker build -t cookcli .
+```
+
+To run the latest version of Cooklang webserver, first create a .env file and set the ROOT variable to the directory where you want to store your recipes. Then run the following command:     
+
+```
+docker compose up -d
+```
+
+The webserver will be available at http://localhost:9080 on the host machine, or at the IP address of the host machine if you are running it on a remote machine.
+
+To stop the webserver, run the following command:     
+
+```
+docker compose down
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+name: Cookcli
+services:
+    cookcli:
+        ports:
+            - 9080:9080
+        network_mode: host
+        volumes:
+            - ${ROOT}/recipes:/recipes # Recipe storage location
+        container_name: cookcli
+        restart: always
+        image: cookcli:latest


### PR DESCRIPTION
This adds a basic Dockerfile and docker-compose.yml that will download and build the latest version of the repo and start hosting it. This should simplify the self-hosting experience for newer users, and allow for easy compartmentalization of the project.