### PR TITLE
Fix issue where index and base_path were not the same when specifying the run directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,11 @@ impl Context {
 }
 
 fn configure_context() -> Result<Context> {
-    let base_path = Utf8Path::new(".").to_path_buf();
+    let args = CliArgs::parse();
+    let base_path = match args.command {
+        Command::Server(ref server_args) => server_args.get_base_path().unwrap_or_else(|| Utf8PathBuf::from(".")),
+        _ => Utf8PathBuf::from("."),
+    };
 
     if !base_path.is_dir() {
         bail!("Base path is not a directory: {base_path}");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,6 +71,12 @@ pub struct ServerArgs {
     open: bool,
 }
 
+impl ServerArgs {
+    pub fn get_base_path(&self) -> Option<Utf8PathBuf> {
+        self.base_path.clone()
+    }
+}
+
 #[tokio::main]
 pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
 


### PR DESCRIPTION
Ran into an issue where `clean_path` was panicking due to a mismatch between the indexed recipe location `./seed` and the path passed into the server `/recipes`. This fixes it by using the server base_path argument if available.