### PR TITLE
add notes to ingredients

### DIFF
--- a/ui/src/Ingredients.svelte
+++ b/ui/src/Ingredients.svelte
@@ -2,6 +2,8 @@
     import {ListGroup, ListGroupItem} from "sveltestrap";
     import {formatGroupedQuantity} from "./quantity";
 
+    import {showIngredientNotes} from "./store.js"
+
     export let ingredients;
 
     function sorted(a, b) {
@@ -14,7 +16,12 @@
 <ListGroup>
 {#each ingredients.sort(sorted) as ingredient}
     <ListGroupItem class="list-group-item d-flex justify-content-between align-items-center border-0">
-        {ingredient.name}
+        <div>
+            {ingredient.name}
+            {#if $showIngredientNotes && ingredient.note}
+                <br><small><i>{ingredient.note}</i></small>
+            {/if}
+        </div>
         <span class="text-muted">{formatGroupedQuantity(ingredient.quantities)}</span>
     </ListGroupItem>
 {/each}

--- a/ui/src/Preferences.svelte
+++ b/ui/src/Preferences.svelte
@@ -1,17 +1,22 @@
 <script>
     import {ListGroup, ListGroupItem, TabContent, TabPane, Button} from "sveltestrap";
 
-    import {showQuantitiesNextToIngredients} from "./store.js";
+    import {showQuantitiesNextToIngredients, showIngredientNotes} from "./store.js";
 </script>
 
 <TabContent>
     <TabPane tabId="preferences" tab="Preferences" active>
-    <!-- add checkbox input to toggle showQuantitiesNextToIngredients store -->
-    <label class="my-3" for="show-quantities-next-to-ingredients">
-        <input type="checkbox" id="show-quantities-next-to-ingredients" bind:checked={$showQuantitiesNextToIngredients}>
-        <span>Show quantities next to ingredients in recipes</span>
-    </label>
-</TabPane>
+        <!-- add checkbox input to toggle showQuantitiesNextToIngredients store -->
+        <label class="my-3" for="show-quantities-next-to-ingredients">
+            <input type="checkbox" id="show-quantities-next-to-ingredients" bind:checked={$showQuantitiesNextToIngredients}>
+            <span>Show quantities next to ingredients in recipes</span>
+        </label>
+        <br>
+        <label class="my-3" for="show-ingredient-notes">
+            <input type="checkbox" id="show-ingredient-notes" bind:checked={$showIngredientNotes}>
+            <span>Show notes next to ingredients</span>
+        </label>
+    </TabPane>
 
 
 </TabContent>

--- a/ui/src/Recipe.svelte
+++ b/ui/src/Recipe.svelte
@@ -29,6 +29,7 @@
     function namedGroupIngredients(grouped, flat) {
         grouped.forEach((ingredient) => {
             ingredient.name = flat[ingredient.index].name;
+            ingredient.note = flat[ingredient.index].note
         });
 
         return grouped;

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -58,3 +58,15 @@ export const showQuantitiesNextToIngredients = writable(JSON.parse(showQuantitie
 showQuantitiesNextToIngredients.subscribe((val) => {
     localStorage.setItem("showQuantitiesNextToIngredients", JSON.stringify(val));
 })
+
+// Preference for showing notes next to ingredients, default is false
+const showIngredientNotesValue =
+  localStorage.getItem("showIngredientNotes") || "false";
+export const showIngredientNotes = writable(
+  JSON.parse(showIngredientNotesValue)
+);
+
+// Subscribe method to update local storage
+showIngredientNotes.subscribe((val) => {
+  localStorage.setItem("showIngredientNotes", JSON.stringify(val));
+});


### PR DESCRIPTION
This feature branch adds the notes feature to ingredients. Quickly hacked together because I was missing the feature, let me know if I can improve it in some way.

<img width="600" alt="Bildschirmfoto 2025-03-16 um 19 07 52" src="https://github.com/user-attachments/assets/1d9e9c48-cf00-4598-97db-660807e0ecac" />
<img width="447" alt="Bildschirmfoto 2025-03-16 um 19 07 55" src="https://github.com/user-attachments/assets/65f9faa8-97d3-4e71-a10b-d245e3fdc933" />
