### PR TITLE
fix: brew install cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ On Linux (or [WSL](https://docs.microsoft.com/en-us/windows/wsl/about)), this is
 On MacOS:
 
     brew tap cooklang/tap
-    brew install cooklang/tap/cook
+    brew install cooklang/tap/cookcli
 
 With Cargo:
 


### PR DESCRIPTION
During following the readme#installation I got an error:
```bash
➜  bbip brew install cooklang/tap/cook
Warning: No available formula or cask with the name "cooklang/tap/cook". Did you mean cooklang/tap/cookcli?
➜  bbip brew install cooklang/tap/cookcli
==> Fetching dependencies for cooklang/tap/cookcli: brotli, c-ares, node, z3, llvm and rust
...
```

So this tiny PR just fix brew install instruction. 