### PR TITLE
chore: update the test snapshot for the update subcommand

### DIFF
--- a/tests/snapshots/snapshot_test__help_output.snap
+++ b/tests/snapshots/snapshot_test__help_output.snap
@@ -16,6 +16,7 @@ Commands:
   report         Generate custom reports from recipes using templates
   doctor         Analyze your recipe collection for issues and improvements
   pantry         Manage and analyze your pantry inventory
+  update         Update CookCLI to the latest version
   help           Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
Fixes this `cargo test` failure which I hit while building the latest version for the AUR:

```
test test_help_output ... FAILED

failures:

---- test_help_output stdout ----
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: tests/snapshots/snapshot_test__help_output.snap
Snapshot: help_output
Source: tests/snapshot_test.rs:303
────────────────────────────────────────────────────────────────────────────────
Expression: stdout
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
   10    10 │   import         Import recipes from supported websites and convert to Cooklang
   11    11 │   report         Generate custom reports from recipes using templates
   12    12 │   doctor         Analyze your recipe collection for issues and improvements
   13    13 │   pantry         Manage and analyze your pantry inventory
         14 │+  update         Update CookCLI to the latest version
   14    15 │   help           Print this message or the help of the given subcommand(s)
   15    16 │
   16    17 │ Options:
   17    18 │   -v, --verbose...  Increase verbosity (-v for info, -vv for debug, -vvv for trace)
────────────┴───────────────────────────────────────────────────────────────────
To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.

thread 'test_help_output' panicked at /build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/insta-1.43.1/src/runtime.rs:679:13:
snapshot assertion for 'help_output' failed in line 303
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_help_output

test result: FAILED. 8 passed; 1 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

Additionally, would it be possible to make self-update opt-out with a feature flag? It's something that we try to avoid in software distributed via package managers.
