### PR TITLE
Add support for time.* metadata

### DIFF
--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -453,10 +453,12 @@ async fn recipe_page(
             course: get_field("course"),
             prep_time: get_field("prep time")
                 .or_else(|| get_field("prep_time"))
-                .or_else(|| get_field("preptime")),
+                .or_else(|| get_field("preptime"))
+                .or_else(|| get_field("time.prep")),
             cook_time: get_field("cook time")
                 .or_else(|| get_field("cook_time"))
-                .or_else(|| get_field("cooktime")),
+                .or_else(|| get_field("cooktime"))
+                .or_else(|| get_field("time.cook")),
             cuisine: get_field("cuisine"),
             diet: get_field("diet"),
             author: get_field("author"),


### PR DESCRIPTION
While testing the latest version of the Cooklang CLI, I've noticed that `time.cook` and `time.prep` were not parsed. This PR should fix it.

See https://github.com/cooklang/spec?tab=readme-ov-file#canonical-metadata for reference.