### PR TITLE
Enable default extensions for CLI and web UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,10 +556,14 @@ dependencies = [
  "codesnake",
  "enum-map",
  "finl_unicode",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_yaml",
  "smallvec",
  "strum",
+ "syn",
  "thiserror 2.0.12",
  "toml 0.8.23",
  "tracing",
@@ -2373,6 +2377,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ axum = { version = "0.7" }
 camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
-cooklang = { version = "0.17.1", default-features = false, features = ["aisle", "pantry"] }
+cooklang = { version = "0.17.1", default-features = false, features = ["aisle", "pantry", "bundled_units"] }
 cooklang-find = { version = "0.5.0" }
 cooklang-import = "0.6.0"
 cooklang-reports = { version = "0.2" }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -51,8 +51,8 @@ use tracing::warn;
 pub const RECIPE_SCALING_DELIMITER: char = ':';
 
 pub static PARSER: Lazy<CooklangParser> = Lazy::new(|| {
-    // Use no extensions but with default converter for basic unit support
-    CooklangParser::new(Extensions::empty(), Converter::default())
+    // Use default converter for basic unit support
+    CooklangParser::new(Extensions::all(), Converter::default())
 });
 
 /// Parse a Recipe from a RecipeEntry with the given scaling factor


### PR DESCRIPTION
This change enables the extensions by default in the web UI and CLI. **I don't know if this has any consequences that I'm unaware of**, but it's there currently seems to be no way to enable extensions without doing so directly in the code. If this change is undesirable, I'm happy to just keep it in my own fork for now.