### PR TITLE
fix: unexpected notes rendering

### DIFF
--- a/src/server/templates.rs
+++ b/src/server/templates.rs
@@ -176,14 +176,20 @@ pub struct CookwareData {
 #[derive(Debug, Clone, Serialize)]
 pub struct RecipeSection {
     pub name: Option<String>,
-    pub steps: Vec<StepData>,
-    pub notes: Vec<String>,
+    pub items: Vec<RecipeSectionItem>,
     pub step_offset: usize,
     pub ingredients: Vec<IngredientData>,
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub enum RecipeSectionItem {
+    Step(StepData),
+    Note(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct StepData {
+    pub number: usize,
     pub items: Vec<StepItem>,
     pub ingredients: Vec<StepIngredient>,
     pub image_path: Option<String>,

--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -275,49 +275,46 @@
                     {% when None %}
                     {% endmatch %}
 
-                    {% if section.notes.len() > 0 %}
-                    <div class="mb-4">
-                        {% for note in section.notes %}
-                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 rounded-xl p-4 mb-3 border-l-4 border-blue-400">
-                            <div class="flex items-start gap-2">
-                                <span class="text-blue-600">📝</span>
-                                <p class="text-gray-700 italic">{{ note }}</p>
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                    {% endif %}
-
                     <ol class="space-y-4 {% if !loop.first %}mt-4{% endif %}">
-                        {% for step in section.steps %}
-                        <li class="bg-gradient-to-r from-gray-50 to-orange-50 rounded-xl p-4">
-                            <div class="flex flex-col gap-4">
-                                {% match step.image_path %}
-                                {% when Some with (img) %}
-                                <img class="image-step" src="{{ img }}" />
-                                {% when None %}
-                                {% endmatch %}
-                                <div class="flex gap-4">
-                                    <div class="step-number">{{ section.step_offset + loop.index }}</div>
-                                    <div class="flex-1">
-                                        <div class="text-gray-700 mb-2 leading-8">
-                                        {% for item in step.items %}
-                                            {% match item %}
-                                                {% when crate::server::templates::StepItem::Text with (text) %}{{ text }}{% when crate::server::templates::StepItem::Ingredient with { name, reference_path } %}{% match reference_path %}{% when Some with (path) %}<a href="/recipe/{{ path }}" class="ingredient-badge hover:underline" title="View recipe: {{ name }}">{{ name }}</a>{% when None %}<span class="ingredient-badge">{{ name }}</span>{% endmatch %}{% when crate::server::templates::StepItem::Cookware with (name) %}<span class="cookware-badge">{{ name }}</span>{% when crate::server::templates::StepItem::Timer with (name) %}<span class="timer-badge">⏱️ {{ name }}</span>{% when crate::server::templates::StepItem::Quantity with (qty) %}<span class="font-bold text-orange-600">{{ qty }}</span>{% endmatch %}{% endfor %}
+                        {% for item in section.items %}
+                            {% match item %}
+                                {% when crate::server::templates::RecipeSectionItem::Step with (step) %}
+                                <li class="bg-gradient-to-r from-gray-50 to-orange-50 rounded-xl p-4">
+                                    <div class="flex flex-col gap-4">
+                                        {% match step.image_path %}
+                                        {% when Some with (img) %}
+                                        <img class="image-step" src="{{ img }}" />
+                                        {% when None %}
+                                        {% endmatch %}
+                                        <div class="flex gap-4">
+                                            <div class="step-number">{{ section.step_offset + step.number }}</div>
+                                            <div class="flex-1">
+                                                <div class="text-gray-700 mb-2 leading-8">
+                                                {% for step_item in step.items %}
+                                                    {% match step_item %}
+                                                        {% when crate::server::templates::StepItem::Text with (text) %}{{ text }}{% when crate::server::templates::StepItem::Ingredient with { name, reference_path } %}{% match reference_path %}{% when Some with (path) %}<a href="/recipe/{{ path }}" class="ingredient-badge hover:underline" title="View recipe: {{ name }}">{{ name }}</a>{% when None %}<span class="ingredient-badge">{{ name }}</span>{% endmatch %}{% when crate::server::templates::StepItem::Cookware with (name) %}<span class="cookware-badge">{{ name }}</span>{% when crate::server::templates::StepItem::Timer with (name) %}<span class="timer-badge">⏱️ {{ name }}</span>{% when crate::server::templates::StepItem::Quantity with (qty) %}<span class="font-bold text-orange-600">{{ qty }}</span>{% endmatch %}{% endfor %}
+                                                </div>
+                                                {% if step.ingredients.len() > 0 %}
+                                                <div class="text-sm text-gray-600 mt-2 pl-4 border-l-2 border-orange-300">
+                                                    {% for ing in step.ingredients %}
+                                                        <span class="inline-block mr-3">
+                                                            {{ ing.name }}{% match ing.quantity %}{% when Some with (q) %}: {{ q }}{% when None %}{% endmatch %}{% match ing.unit %}{% when Some with (u) %} {{ u }}{% when None %}{% endmatch %}{% match ing.note %}{% when Some with (note) %} <span class="italic text-gray-600 truncate max-w-[200px] inline-block align-bottom" title="{{ note }}" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>{% when None %}{% endmatch %}{% if !loop.last %},{% endif %}
+                                                        </span>
+                                                    {% endfor %}
+                                                </div>
+                                                {% endif %}
+                                            </div>
                                         </div>
-                                        {% if step.ingredients.len() > 0 %}
-                                        <div class="text-sm text-gray-600 mt-2 pl-4 border-l-2 border-orange-300">
-                                            {% for ing in step.ingredients %}
-                                                <span class="inline-block mr-3">
-                                                    {{ ing.name }}{% match ing.quantity %}{% when Some with (q) %}: {{ q }}{% when None %}{% endmatch %}{% match ing.unit %}{% when Some with (u) %} {{ u }}{% when None %}{% endmatch %}{% match ing.note %}{% when Some with (note) %} <span class="italic text-gray-600 truncate max-w-[200px] inline-block align-bottom" title="{{ note }}" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>{% when None %}{% endmatch %}{% if !loop.last %},{% endif %}
-                                                </span>
-                                            {% endfor %}
-                                        </div>
-                                        {% endif %}
                                     </div>
-                                </div>
-                            </div>
-                        </li>
+                                </li>
+                                {% when crate::server::templates::RecipeSectionItem::Note with (note) %}
+                                <li class="bg-gradient-to-r from-blue-50 to-purple-50 rounded-xl p-4 mb-3 border-l-4 border-blue-400">
+                                    <div class="flex items-start gap-2">
+                                        <span class="text-blue-600">📝</span>
+                                        <p class="text-gray-700 italic">{{ note }}</p>
+                                    </div>
+                                </li>
+                            {% endmatch %}
                         {% endfor %}
                     </ol>
                 {% endfor %}


### PR DESCRIPTION
Fixes #200

Tested with test.cook (and test.2.jpg + test.7.jpg):
```
= Section 1

Step 1

> Note 1

> Note 2

Step 2

> Note 3

Step 3

= Section 2

> Note 4

Step 1

Step 1

= Section 3

Step 1

Step 2

Step 3

> Note 5
```
Before the fix:

<img width="726" height="2080" alt="grafik" src="https://github.com/user-attachments/assets/f2ba6ca1-ccec-429d-a850-0516ce1ee161" />

After the fix:
<img width="729" height="2130" alt="grafik" src="https://github.com/user-attachments/assets/410ef17f-77a1-4f45-b338-e308066300bf" />

The example from issue #200 is now rendered correctly:
<img width="497" height="770" alt="grafik" src="https://github.com/user-attachments/assets/035a78f2-0129-4b89-a096-1c3a081b7e50" />
