### PR TITLE
fix: removing all items from pantry removes the section

### DIFF
--- a/src/server/templates.rs
+++ b/src/server/templates.rs
@@ -98,6 +98,7 @@ pub struct PreferencesTemplate {
 #[template(path = "pantry.html")]
 pub struct PantryTemplate {
     pub active: String,
+    pub configured: bool,
     pub sections: Vec<PantrySection>,
     pub tr: Tr,
 }

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -801,6 +801,7 @@ async fn pantry_page(
 
     Ok(PantryTemplate {
         active: "pantry".to_string(),
+        configured: pantry_path.is_some(),
         sections,
         tr: Tr::new(lang),
     })

--- a/templates/pantry.html
+++ b/templates/pantry.html
@@ -18,7 +18,7 @@
         </div>
     </div>
 
-    {% if sections.is_empty() %}
+    {% if !configured %}
     <div class="recipe-card">
         <div class="p-8 text-center">
             <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
Fixes #191

The real problem of the issue seemed to be that if pantry.conf got empty, there was no possibility to add items via the web interface. Now that is possible. Only if pantry.conf is not found, the correct hint is displayed.

Removing the last item of a section still removes the section, which I think is valid behaviour.