### PR TITLE
ci: setup trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -307,8 +307,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Authenticate | crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish | crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
> This approach eliminates the security risks associated with long-lived write tokens, which can be compromised, accidentally exposed in logs, or require manual rotation. (npmjs.com)

There is still a little bit of manual work you'll need to do before this will work: https://crates.io/docs/trusted-publishing

The `CARGO_REGISTRY_TOKEN` secret can be deleted after this is merged.