### PR TITLE
Include 'npm run build-js' in relevant actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: Build CSS
         run: npm run build-css
 
+      - name: Build JS
+        run: npm run build-js
+
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -302,6 +305,9 @@ jobs:
 
       - name: Build CSS
         run: npm run build-css
+
+      - name: Build JS
+        run: npm run build-js
 
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Build CSS
       run: npm run build-css
 
+    - name: Build JS
+      run: npm run build-js
+
     - name: Check formatting
       run: cargo fmt -- --check
 
@@ -106,6 +109,7 @@ jobs:
       run: |
         cargo build
         npm run build-css
+        npm run build-js
 
     - name: Cache Playwright browsers
       uses: actions/cache@v4
@@ -170,6 +174,9 @@ jobs:
     - name: Build CSS
       run: npm run build-css
 
+    - name: Build JS
+      run: npm run build-js
+
     - name: Build
       run: cargo build --verbose
 
@@ -218,6 +225,9 @@ jobs:
 
     - name: Build CSS
       run: npm run build-css
+
+    - name: Build JS
+      run: npm run build-js
 
     - name: Generate code coverage
       run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@ make build  # Includes CSS compilation
 make css
 npm run build-css
 
+# Build JS only
+make js
+npm run build-js
+
 # Build specific workspace member
 cargo build -p cookcli
 
@@ -61,6 +65,12 @@ npm run build-css
 
 # Watch CSS changes during development
 npm run watch-css
+
+# Build JS for production
+npm run build-js
+
+# Watch JS changes during development
+npm run watch-js
 ```
 
 ### Linting and Formatting

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
   webServer: {
     command: process.env.CI
       ? './target/debug/cook server ./seed --port 9080'  // In CI, use pre-built binary
-      : 'npm run build-css && cargo build && ./target/debug/cook server ./seed --port 9080',  // Local dev
+      : 'npm run build-css && npm run build-js && cargo build && ./target/debug/cook server ./seed --port 9080',  // Local dev
     url: 'http://localhost:9080',
     reuseExistingServer: !process.env.CI,
     timeout: 60 * 1000, // 1 minute should be enough with pre-built binary


### PR DESCRIPTION
Should fix #253

Did not directly test the action but ran the steps in the action by hand (including `npm run build-js`), launched the server with `cook --host /my/recipes`, and see the bundle now served and the editor UI appears to work correctly:

<img width="569" height="80" alt="image" src="https://github.com/user-attachments/assets/c39a6279-66c1-4cdc-85a0-650c05b4fca3" />
