### PR TITLE
fix: filter artifact download in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -271,6 +271,8 @@ jobs:
     steps:
       - name: Setup | Artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: cook-*
 
       - name: Setup | Checksums
         run: for file in cook-*/cook-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done


### PR DESCRIPTION
## Summary
- The `download-artifact@v4` step in the release job was downloading **all** artifacts, including Docker build cache artifacts (`cooklang~cookcli~*.dockerbuild`), which consistently failed after 5 retries and blocked the release
- Added `pattern: cook-*` filter to only download the release binary artifacts

## Test plan
- [ ] Trigger a release and verify the "Add Build Artifacts to Release" job completes successfully