### PR TITLE
fix: resolve Docker volume permission issues when creating recipes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,5 @@ USER cookcli
 VOLUME /recipes
 EXPOSE 9080
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["cook", "server", "/recipes", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   cookcli:
     image: ghcr.io/cooklang/cookcli:latest
-    # Set user to match your host UID:GID to avoid permission issues with mounted volumes.
-    # Find your IDs with: id -u && id -g
-    user: "1000:1000"
+    # Uncomment and set to your host UID:GID to avoid permission issues with mounted volumes.
+    # Find your IDs with: id -u && id -g (default container user is 1000:1000)
+    # user: "1000:1000"
     ports:
       - "9080:9080"
     volumes:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 set -e
 
+# Check if /recipes directory exists
+if [ ! -d /recipes ]; then
+    echo "ERROR: /recipes directory does not exist."
+    echo ""
+    echo "Mount your recipes directory in docker-compose.yml:"
+    echo ""
+    echo "  volumes:"
+    echo "    - ./recipes:/recipes"
+    echo ""
+    exit 1
+fi
+
 # Check if /recipes directory is writable
 if [ ! -w /recipes ]; then
     echo "ERROR: /recipes directory is not writable by user $(id -u):$(id -g)."

--- a/src/server/handlers/recipes.rs
+++ b/src/server/handlers/recipes.rs
@@ -205,10 +205,12 @@ pub async fn recipe_save(
     let temp_path = file_path.with_extension("tmp");
 
     let mut temp_file = tokio::fs::File::create(&temp_path).await.map_err(|e| {
-        tracing::error!("Failed to create temp file {}: {}. If running in Docker, ensure the mounted volume is writable by the container user.", temp_path, e);
+        tracing::error!("Failed to create temp file {}: {}", temp_path, e);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            json_error(format!("Failed to save recipe: {e}. Check that the recipes folder has write permissions.")),
+            json_error(format!(
+                "Failed to save recipe: {e}. Check that the recipes folder has write permissions."
+            )),
         )
     })?;
 

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -950,7 +950,7 @@ async fn create_recipe(
         // Create parent directories if they don't exist
         if !parent.exists() {
             if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                tracing::error!("Failed to create directories: {}. If running in Docker, ensure the mounted volume is writable by the container user. Set `user: \"YOUR_UID:YOUR_GID\"` in docker-compose.yml.", e);
+                tracing::error!("Failed to create directories: {}", e);
                 return new_page_error("Failed to create directory. Check that the recipes folder has write permissions.", &original_filename);
             }
         }


### PR DESCRIPTION
## Summary

Fixes #287 — "Failed to create directory" permission error when creating recipes via the web UI in Docker.

- **Use UID/GID 1000** for the `cookcli` container user instead of a system user (`useradd -r`), matching the default first user on most Linux systems
- **Add entrypoint script** that checks `/recipes` is writable on startup and prints actionable guidance if not (suggesting `user: "UID:GID"` in docker-compose.yml)
- **Set `user: "1000:1000"`** explicitly in docker-compose.yml so it's visible and easy to override
- **Improve error messages** in recipe creation/save handlers to mention write permissions

## Test plan

- [ ] Build Docker image: `docker build -t cookcli .`
- [ ] Run with default docker-compose.yml and verify recipes can be created
- [ ] Run with a volume mounted from a host directory and verify write permissions work
- [ ] Verify the entrypoint script shows a helpful error when /recipes is not writable