### PR TITLE
Improve JSON-LD schema.org output for HowToStep

### DIFF
--- a/src/util/cooklang_to_schema.rs
+++ b/src/util/cooklang_to_schema.rs
@@ -354,6 +354,8 @@ fn build_step(recipe: &Recipe, step: &cooklang::model::Step, step_number: usize)
 
                     // Accumulate timer duration for timeRequired.
                     // Range values are averaged (e.g. 15-30 min → 22.5 min).
+                    // Note: the parser produces Range only from scaling operations,
+                    // not from syntax like ~{15-30%min} (which parses as Text).
                     let seconds = match quantity.value() {
                         cooklang::quantity::Value::Number(n) => Some(n.value()),
                         cooklang::quantity::Value::Range { start, end } => {
@@ -367,7 +369,7 @@ fn build_step(recipe: &Recipe, step: &cooklang::model::Step, step_number: usize)
                             Some("s" | "sec" | "second" | "seconds") => Some(1.0),
                             Some("h" | "hr" | "hour" | "hours") => Some(3600.0),
                             // Cooklang timers without an explicit unit default to minutes
-                            Some("min" | "minute" | "minutes") | None => Some(60.0),
+                            Some("m" | "min" | "minute" | "minutes") | None => Some(60.0),
                             Some(_) => None, // unknown unit — skip rather than guess
                         };
                         if let Some(m) = multiplier {

--- a/tests/schema_output_test.rs
+++ b/tests/schema_output_test.rs
@@ -97,6 +97,24 @@ fn test_schema_step_no_timer_no_time_required() {
 }
 
 #[test]
+fn test_schema_text_only_timer_no_time_required() {
+    // A timer with only a text name and no numeric quantity should not
+    // produce timeRequired, but should still appear in step text.
+    let json = schema_output("Wait until ~{golden brown}.");
+
+    let step = &json["recipeInstructions"][0];
+    assert!(
+        step.get("timeRequired").is_none(),
+        "Text-only timers should not produce timeRequired"
+    );
+    let text = step["text"].as_str().unwrap();
+    assert!(
+        text.contains("golden brown"),
+        "Timer name should appear in step text"
+    );
+}
+
+#[test]
 fn test_schema_sections_produce_how_to_section() {
     let json = schema_output(
         "\


### PR DESCRIPTION
## Summary

Fixes #291 — improves the schema.org JSON-LD recipe output in three ways:

- **`position` instead of `name`**: Replaces `"name": "Step N"` with `"position": N` integer property on `HowToStep`, as recommended by [schema.org/HowToStep](https://schema.org/HowToStep)
- **`timeRequired` from timers**: Extracts timer durations from steps and adds `"timeRequired"` in ISO 8601 format (e.g. `"PT40M"`). Multiple timers in a step are summed. Supports seconds, minutes, and hours units.
- **`HowToSection` for named sections**: When a recipe has named sections (e.g. `== Preparation ==`), steps are wrapped in `HowToSection` objects with a `name` field. Recipes without sections continue to emit a flat list of `HowToStep`.

## Example output

Given a recipe with sections and timers:

```json
{
  "recipeInstructions": [
    {
      "@type": "HowToSection",
      "name": "Preparation",
      "itemListElement": [
        {
          "@type": "HowToStep",
          "position": 1,
          "text": "Whisk olive oil, maple syrup, ..."
        }
      ]
    },
    {
      "@type": "HowToSection",
      "name": "Cooking",
      "itemListElement": [
        {
          "@type": "HowToStep",
          "position": 2,
          "text": "Toss the glaze with sweet potatoes ..., 40 minutes.",
          "timeRequired": "PT40M"
        }
      ]
    }
  ]
}
```

## Test plan

- [x] Tested with the example recipe from #291 (sections + timers)
- [x] Tested with recipe without sections (flat HowToStep output)
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied