### PR TITLE
Write back non-ASCII pantry key when updating

### DIFF
--- a/src/pantry.rs
+++ b/src/pantry.rs
@@ -88,7 +88,12 @@ fn write_pantry_item(output: &mut String, item: &cooklang::pantry::PantryItem) {
 }
 
 fn toml_escape_key(key: &str) -> String {
-    if key.contains(' ') || key.contains('.') || key.contains('[') || key.contains(']') {
+    if key.contains(' ')
+        || key.contains('.')
+        || key.contains('[')
+        || key.contains(']')
+        || !key.is_ascii()
+    {
         format!("\"{}\"", key.replace('"', "\\\""))
     } else {
         key.to_string()

--- a/src/server/handlers/pantry.rs
+++ b/src/server/handlers/pantry.rs
@@ -442,7 +442,12 @@ fn write_pantry_item(output: &mut String, item: &cooklang::pantry::PantryItem) {
 
 fn toml_escape_key(key: &str) -> String {
     // If the key contains special characters or spaces, quote it
-    if key.contains(' ') || key.contains('.') || key.contains('[') || key.contains(']') {
+    if key.contains(' ')
+        || key.contains('.')
+        || key.contains('[')
+        || key.contains(']')
+        || !key.is_ascii()
+    {
         format!("\"{}\"", key.replace('"', "\\\""))
     } else {
         key.to_string()


### PR DESCRIPTION
TOML doesn't support non-ASCII characters in keys. Such keys need to be inside quotes. When a pantry item is removed, the pantry conf is rewritten and need to consider TOML's constraint.