### PR TITLE
fix: ingredient/cookware names invisible when printing in dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -326,6 +326,20 @@
         }
 
         @media print {
+            /* Reset color-scheme so browser default text color is dark, not
+               light. Without this, elements without an explicit text color
+               (e.g. ingredient/cookware names) inherit the dark-mode default
+               white text and become invisible on the forced white background. */
+            html, html.dark {
+                color-scheme: light !important;
+            }
+
+            /* Default text color for dark mode when printing */
+            .dark,
+            .dark body {
+                color: #111827 !important;
+            }
+
             /* Force light mode for printing */
             .dark body,
             .dark .bg-gray-50,


### PR DESCRIPTION
## Summary
- Fixes #319 — printed recipes were missing ingredient and cookware names when the page was viewed in dark mode before printing.
- Root cause: `.dark { color-scheme: dark; }` makes the browser use dark-mode native defaults (light text). The `@media print` block forced backgrounds white but did not reset `color-scheme`, so unstyled text inherited white and disappeared on the white print background. Elements with explicit color classes (e.g. `text-orange-700` quantities) were unaffected, which matches the screenshot in the issue.
- Fix: inside `@media print`, set `color-scheme: light` and an explicit dark `color` on `.dark` / `.dark body` so inherited text is readable.

## Test plan
- [ ] Enable dark mode in the web UI
- [ ] Open a recipe and invoke print preview — verify ingredient names, cookware names, and notes are visible in black
- [ ] Repeat in light mode — verify no regression
- [ ] `cargo fmt --check`, `cargo clippy`, `cargo build` all pass