### PR TITLE
fix: plan card unreadable on shopping list in dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -120,6 +120,16 @@
             border: 1px solid #374151;
         }
 
+        /* Plan cards in the shopping list use an indigo/purple gradient */
+        .dark .bg-gradient-to-r.from-indigo-50.to-purple-50 {
+            background: linear-gradient(to right, #1f2937, #111827);
+            border: 1px solid #374151;
+        }
+
+        .dark .border-indigo-200 {
+            border-color: #4c1d95;
+        }
+
         .dark .border-purple-200 {
             border-color: #4c1d95;
         }


### PR DESCRIPTION
## Summary
- On the shopping list page in dark mode, plan/menu entries rendered as a bright white card with nearly-invisible light-gray text (see issue screenshot).
- Root cause: plan cards use \`bg-gradient-to-r from-indigo-50 to-purple-50\`, but \`templates/base.html\` only had dark-mode overrides for other gradient combos (orange/yellow, gray/orange, green/blue, blue/purple, purple/pink, green/emerald). The indigo/purple combo was missed, so the background stayed light while the inner text classes (\`text-gray-800\`, \`text-gray-600\`, etc.) picked up their dark-mode light colors.
- Fix: add dark-mode overrides for the indigo/purple gradient and the matching \`border-indigo-200\` so plan cards match the other shopping-list cards.

## Test plan
- [ ] Enable dark mode in the web UI
- [ ] Open \`/shopping-list\` with a plan/menu selected (e.g. \"3 Day Plan\" from the seed data)
- [ ] Verify the plan card has a dark background and readable text for the plan name, nested recipes, and \`(×N)\` scale
- [ ] Verify regular (non-plan) recipe cards still render correctly in dark mode
- [ ] Verify light mode is unchanged