### PR TITLE
fix: include menu freehand ingredients in web shopping list

### DIFF
--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -263,15 +263,23 @@ async function generateList() {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(shoppingList.flatMap(item => {
-                // Plan/menu entry — expand into individual recipe requests
+                // Plan/menu entry — expand into individual recipe requests,
+                // plus the menu itself (with no references) so its freehand
+                // ingredients are included in the shopping list.
                 if (item.recipes) {
-                    return item.recipes.map(recipe => {
+                    const menuFreehand = {
+                        recipe: item.path,
+                        scale: item.scale,
+                        included_references: []
+                    };
+                    const recipeRequests = item.recipes.map(recipe => {
                         const req = { recipe: recipe.path, scale: recipe.scale };
                         if (recipe.included_references) {
                             req.included_references = recipe.included_references;
                         }
                         return req;
                     });
+                    return [menuFreehand, ...recipeRequests];
                 }
                 // Regular recipe entry
                 const req = { recipe: item.path, scale: item.scale };


### PR DESCRIPTION
## Summary
- Web shopping list was missing freehand ingredients from `.menu` files (e.g. `@coffee{1%cup}` directly in a menu), causing it to diverge from `cook shopping-list foo.menu`
- When expanding a plan/menu entry in `templates/shopping_list.html`, also emit a request for the menu path itself with `included_references: []` — `extract_ingredients` then adds the menu's non-reference ingredients and skips every recipe reference (already covered by the per-recipe requests)

## Test plan
- [x] Verified CLI `cook shopping-list "2 Day Plan.menu"` already produces freehand items (`maple syrup`, `coffee`, `bread`, `soy sauce`, `oats`, `sugar`, `orange juice`, `green salad`)
- [x] Reproduced missing items in web UI via `/api/shopping_list` with old payload shape
- [x] Confirmed with the fix the same payload now yields those items (diff: `+bread +coffee +green salad +maple syrup +oats +orange juice +soy sauce +sugar`)