### PR TITLE
fix: escape single quotes in JS string literals to prevent XSS

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -832,7 +832,7 @@
     <script>
         // Translations for JavaScript
         const translations = {
-            noRecipes: "{{ tr.t("search-no-results") }}"
+            noRecipes: {{ tr.t("search-no-results")|json|safe }}
         };
 
         // Theme toggle function

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -237,6 +237,19 @@
 </div>
 
 <script>
+// Escape a string for safe interpolation into HTML text content. Even
+// though translated strings are compile-time today, defensively escaping
+// matches the pattern used in shopping_list.html and prevents any future
+// translation source from injecting markup via innerHTML.
+function escHtml(s) {
+    return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 async function addToShoppingList(event, recipePath) {
     event.preventDefault();
     const button = event.currentTarget;
@@ -256,7 +269,7 @@ async function addToShoppingList(event, recipePath) {
         });
 
         if (response.ok) {
-            button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg> ' + {{ tr.t("recipe-added")|json|safe }};
+            button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg> ' + escHtml({{ tr.t("recipe-added")|json|safe }});
             button.classList.add('bg-green-500', 'hover:bg-green-600');
             button.classList.remove('from-purple-500', 'to-pink-500', 'hover:from-purple-600', 'hover:to-pink-600');
 
@@ -270,7 +283,7 @@ async function addToShoppingList(event, recipePath) {
         }
     } catch (error) {
         console.error('Error:', error);
-        button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg> ' + {{ tr.t("shopping-error")|json|safe }};
+        button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg> ' + escHtml({{ tr.t("shopping-error")|json|safe }});
         button.classList.add('bg-red-500', 'hover:bg-red-600');
 
         setTimeout(() => {

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -58,7 +58,7 @@
                     </svg>
                     <span class="hidden lg:inline">{{ tr.t("action-edit") }}</span>
                 </a>
-                <button onclick="addToShoppingList(event, '{{ recipe_path }}')"
+                <button onclick="addToShoppingList(event, {{ recipe_path|json }})"
                         class="px-3 lg:px-4 py-2 text-sm lg:text-base bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all shadow-md flex items-center gap-1.5 lg:gap-2 whitespace-nowrap"
                         title="{{ tr.t("recipe-add-all-to-shopping") }}">
                     <svg class="w-4 h-4 lg:w-5 lg:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -256,7 +256,7 @@ async function addToShoppingList(event, recipePath) {
         });
 
         if (response.ok) {
-            button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg> {{ tr.t("recipe-added") }}';
+            button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg> ' + {{ tr.t("recipe-added")|json|safe }};
             button.classList.add('bg-green-500', 'hover:bg-green-600');
             button.classList.remove('from-purple-500', 'to-pink-500', 'hover:from-purple-600', 'hover:to-pink-600');
 
@@ -266,11 +266,11 @@ async function addToShoppingList(event, recipePath) {
                 button.classList.add('from-purple-500', 'to-pink-500', 'hover:from-purple-600', 'hover:to-pink-600');
             }, 2000);
         } else {
-            throw new Error('{{ tr.t("shopping-failed-to-add") }}');
+            throw new Error({{ tr.t("shopping-failed-to-add")|json|safe }});
         }
     } catch (error) {
         console.error('Error:', error);
-        button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg> {{ tr.t("shopping-error") }}';
+        button.innerHTML = '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg> ' + {{ tr.t("shopping-error")|json|safe }};
         button.classList.add('bg-red-500', 'hover:bg-red-600');
 
         setTimeout(() => {

--- a/templates/pantry.html
+++ b/templates/pantry.html
@@ -252,7 +252,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (!emptyMessage) {
                         const message = document.createElement('p');
                         message.className = 'empty-section-message text-gray-500 italic';
-                        message.textContent = '{{ tr.t("pantry-no-out-of-stock") }}';
+                        message.textContent = {{ tr.t("pantry-no-out-of-stock")|json|safe }};
                         sectionContainer.parentNode.appendChild(message);
                     }
                 } else {
@@ -418,7 +418,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     window.location.reload();
                 } else {
                     const data = await response.json().catch(() => ({}));
-                    showPantryError(data.error || '{{ tr.t("pantry-failed-add") }}');
+                    showPantryError(data.error || {{ tr.t("pantry-failed-add")|json|safe }});
                 }
             } catch (error) {
                 showPantryError('Error adding item: ' + error);
@@ -530,7 +530,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     checkOutOfStock();
                 } else {
                     const data = await response.json().catch(() => ({}));
-                    showPantryError(data.error || '{{ tr.t("pantry-failed-update") }}');
+                    showPantryError(data.error || {{ tr.t("pantry-failed-update")|json|safe }});
                 }
             } catch (error) {
                 showPantryError('Error updating item: ' + error);
@@ -562,7 +562,7 @@ document.addEventListener('DOMContentLoaded', function() {
             deleteBtn.addEventListener('click', async function(e) {
                 e.stopPropagation();
 
-                if (confirm('{{ tr.t("pantry-confirm-remove-template") }}'.replace('%s', name).replace('%s', section))) {
+                if (confirm({{ tr.t("pantry-confirm-remove-template")|json|safe }}.replace('%s', name).replace('%s', section))) {
                     try {
                         const response = await fetch(`{{ prefix }}/api/pantry/${section}/${encodeURIComponent(name)}`, {
                             method: 'DELETE'
@@ -582,7 +582,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             }, 200);
                         } else {
                             const data = await response.json().catch(() => ({}));
-                            showPantryError(data.error || '{{ tr.t("pantry-failed-remove") }}');
+                            showPantryError(data.error || {{ tr.t("pantry-failed-remove")|json|safe }});
                         }
                     } catch (error) {
                         showPantryError('Error removing item: ' + error);

--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -58,7 +58,7 @@
                     </svg>
                     <span class="hidden lg:inline">{{ tr.t("action-edit") }}</span>
                 </a>
-                <button onclick="addToShoppingList(event, '{{ recipe_path }}')"
+                <button onclick="addToShoppingList(event, {{ recipe_path|json }})"
                         class="px-3 lg:px-4 py-2 text-sm lg:text-base bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all shadow-md flex items-center gap-1.5 lg:gap-2 whitespace-nowrap"
                         title="{{ tr.t("recipe-add-to-shopping") }}">
                     <svg class="w-4 h-4 lg:w-5 lg:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -396,11 +396,11 @@ async function addToShoppingList(event, recipePath) {
             }, 2000);
         } else {
             const data = await response.json().catch(() => ({}));
-            showRecipeError(data.error || '{{ tr.t("shopping-failed-to-add") }}');
+            showRecipeError(data.error || {{ tr.t("shopping-failed-to-add")|json|safe }});
         }
     } catch (error) {
         console.error('Failed to add to shopping list:', error);
-        showRecipeError('{{ tr.t("shopping-failed-to-add") }}');
+        showRecipeError({{ tr.t("shopping-failed-to-add")|json|safe }});
     }
 }
 

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -107,8 +107,8 @@ function renderSelectedRecipes() {
     const container = document.getElementById('selected-recipes');
 
     if (shoppingList.length === 0) {
-        container.innerHTML = '<p class="text-gray-500 text-sm">{{ tr.t("shopping-no-recipes") }}</p>';
-        document.getElementById('list-content').innerHTML = '<p class="text-gray-500">{{ tr.t("shopping-no-items") }}</p>';
+        container.innerHTML = '<p class="text-gray-500 text-sm">' + escHtml({{ tr.t("shopping-no-recipes")|json|safe }}) + '</p>';
+        document.getElementById('list-content').innerHTML = '<p class="text-gray-500">' + escHtml({{ tr.t("shopping-no-items")|json|safe }}) + '</p>';
         return;
     }
 
@@ -252,7 +252,7 @@ async function generateList() {
     hideError();
 
     if (shoppingList.length === 0) {
-        showError('{{ tr.t("shopping-add-recipes-first") }}');
+        showError({{ tr.t("shopping-add-recipes-first")|json|safe }});
         return;
     }
 
@@ -292,13 +292,13 @@ async function generateList() {
 
         const data = await response.json();
         if (!response.ok) {
-            showError(data.error || '{{ tr.t("shopping-failed-to-generate") }}');
+            showError(data.error || {{ tr.t("shopping-failed-to-generate")|json|safe }});
             return;
         }
         displayShoppingList(data);
     } catch (error) {
         console.error('Failed to generate shopping list:', error);
-        showError('{{ tr.t("shopping-failed-to-generate") }}');
+        showError({{ tr.t("shopping-failed-to-generate")|json|safe }});
     }
 }
 
@@ -416,7 +416,7 @@ function displayShoppingList(data) {
 
     // Display items to buy (organized by aisle)
     if (data.categories && data.categories.length > 0) {
-        html += '<h2 class="text-2xl font-bold mb-4 text-orange-700">{{ tr.t("shopping-title") }}</h2>';
+        html += '<h2 class="text-2xl font-bold mb-4 text-orange-700">' + escHtml({{ tr.t("shopping-title")|json|safe }}) + '</h2>';
         html += data.categories.map(category => `
             <div class="mb-6 bg-white rounded-lg p-4 shadow-sm">
                 <h3 class="font-semibold text-lg mb-3 text-orange-600">${escHtml(category.category)}</h3>
@@ -476,7 +476,7 @@ function displayShoppingList(data) {
     }
 
     if (html === '') {
-        contentDiv.innerHTML = '<p class="text-gray-500">{{ tr.t("shopping-no-items") }}</p>';
+        contentDiv.innerHTML = '<p class="text-gray-500">' + escHtml({{ tr.t("shopping-no-items")|json|safe }}) + '</p>';
     } else {
         contentDiv.innerHTML = html;
         // Load saved checked states


### PR DESCRIPTION
## Summary

- Recipe names or translations containing a `'` were HTML-escaped to `&#x27;` and landed inside JS string literals (inline `onclick` handlers and `<script>` blocks). In attributes, the browser HTML-decodes *before* JS parses, so the escaped apostrophe broke the string — a stored XSS via recipe filename and a display bug for French translations like `Échec de l'ajout…`.
- Replace the ad-hoc `'{{ … }}'` pattern with Askama's `|json` filter (enabled via the existing `serde-json` feature). JSON is a subset of JS, so `{{ v|json }}` produces a full, safely-quoted JS string literal. In attribute context the embedded `"` becomes `&quot;` and decodes cleanly; inside `<script>`, `|json|safe` emits raw valid JS.
- Touches `recipe.html`, `menu.html`, `shopping_list.html`, `pantry.html`, `base.html`. No behavioral change for non-apostrophe strings.

Closes #315

## Test plan

- [x] `cargo build`, `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all clean
- [x] Created `seed/Nids d'hirondelles.cook`, ran server with `Accept-Language: fr-FR`
- [x] Verified rendered HTML: `onclick="addToShoppingList(event, &quot;Nids d\u0027hirondelles.cook&quot;)"` (valid JS after HTML decode) and `showRecipeError("Échec de l\u0027ajout à la liste de courses")` (no more literal `&#x27;`)
- [x] Swept all affected pages (`/`, recipe, menu, shopping_list, pantry, preferences) for remaining `&#x27;` in JS contexts — none found; remaining instances are in safe HTML text/attribute contexts