### PR TITLE
fix: scale menu recipe references by servings/yield

### DIFF
--- a/src/server/handlers/shopping_list.rs
+++ b/src/server/handlers/shopping_list.rs
@@ -433,15 +433,32 @@ pub struct AddMenuRequest {
     pub scale: f64,
 }
 
-/// Resolve the sub-recipe reference paths for a given recipe.
-fn resolve_recipe_references(
-    base_path: &Utf8PathBuf,
-    recipe_path: &str,
-) -> anyhow::Result<Vec<String>> {
+/// Information about a referenced recipe needed to convert a menu's
+/// `{target%unit}` into a storage multiplier for `.shopping-list`.
+struct RecipeInfo {
+    sub_refs: Vec<String>,
+    default_servings: Option<u32>,
+    /// Parsed `yield` metadata (value, unit) if present and well-formed,
+    /// e.g. `yield: 500%ml` → `Some((500.0, "ml"))`.
+    default_yield: Option<(f64, String)>,
+}
+
+/// Parse `"VALUE%UNIT"` (the only format `scale_to_yield` accepts) into its parts.
+fn parse_yield(s: &str) -> Option<(f64, String)> {
+    let (value, unit) = s.split_once('%')?;
+    let value = value.trim().parse::<f64>().ok()?;
+    let unit = unit.trim();
+    if unit.is_empty() {
+        return None;
+    }
+    Some((value, unit.to_string()))
+}
+
+fn resolve_recipe_info(base_path: &Utf8PathBuf, recipe_path: &str) -> anyhow::Result<RecipeInfo> {
     let entry = crate::util::get_recipe(base_path, recipe_path)?;
     let recipe = crate::util::parse_recipe_from_entry(&entry, 1.0)?;
 
-    let mut refs = Vec::new();
+    let mut sub_refs = Vec::new();
     for ingredient in &recipe.ingredients {
         if let Some(ref recipe_ref) = ingredient.reference {
             let path = if recipe_ref.components.is_empty() {
@@ -449,10 +466,21 @@ fn resolve_recipe_references(
             } else {
                 format!("{}/{}", recipe_ref.components.join("/"), recipe_ref.name)
             };
-            refs.push(path);
+            sub_refs.push(path);
         }
     }
-    Ok(refs)
+    let default_servings = recipe.metadata.servings().and_then(|s| s.as_number());
+    let default_yield = recipe
+        .metadata
+        .get("yield")
+        .and_then(|v| v.as_str())
+        .and_then(parse_yield);
+
+    Ok(RecipeInfo {
+        sub_refs,
+        default_servings,
+        default_yield,
+    })
 }
 
 /// Add all recipe references from a menu to the shopping list as a single
@@ -495,28 +523,92 @@ pub async fn add_menu_to_shopping_list(
                 format!("{}/{}", recipe_ref.components.join("/"), recipe_ref.name)
             };
 
-            // Recipe's own quantity × menu global scale
-            let recipe_quantity = ingredient.quantity.as_ref().and_then(|q| match q.value() {
-                cooklang::quantity::Value::Number(n) => Some(n.value()),
-                _ => None,
-            });
-            let final_scale = recipe_quantity
-                .map(|q| q * menu_scale)
-                .unwrap_or(menu_scale);
-
-            // Resolve this recipe's sub-recipe references
+            // Resolve this recipe's sub-recipe references, default servings, and yield
             let ref_path_for_find = recipe_ref.path(std::path::MAIN_SEPARATOR_STR);
-            let sub_refs = match resolve_recipe_references(&state.base_path, &ref_path_for_find) {
-                Ok(refs) => refs,
+            let info = match resolve_recipe_info(&state.base_path, &ref_path_for_find) {
+                Ok(info) => info,
                 Err(e) => {
                     tracing::warn!(
-                        "Could not resolve sub-references for '{}': {}",
+                        "Could not resolve referenced recipe '{}': {}",
                         ref_display,
                         e
                     );
-                    Vec::new()
+                    RecipeInfo {
+                        sub_refs: Vec::new(),
+                        default_servings: None,
+                        default_yield: None,
+                    }
                 }
             };
+
+            // Convert `{target%unit}` on the menu reference into a scale
+            // multiplier for `.shopping-list`. Per the Cooklang spec
+            // (conventions.md §"Scaling Referenced Recipes") the unit
+            // decides how `target` is interpreted:
+            //
+            //   - no unit     → raw multiplier (`{2}` = ×2)
+            //   - `servings`  → target servings; factor = target / default_servings
+            //   - other unit  → target yield;    factor = target / default_yield_value
+            //                   (only if the units match — no conversion)
+            //
+            // Storing a raw multiplier without this conversion was the bug:
+            // e.g. a 2-serving recipe referenced as `{3%servings}` got stored
+            // as `{3}` and scaled to 6 servings instead of 3.
+            let recipe_factor = match ingredient.quantity.as_ref() {
+                Some(q) => {
+                    let value = match q.value() {
+                        cooklang::quantity::Value::Number(n) => Some(n.value()),
+                        _ => None,
+                    };
+                    match (value, q.unit()) {
+                        (None, _) => 1.0,
+                        (Some(v), None) => v,
+                        (Some(target), Some("servings" | "serving")) => {
+                            match info.default_servings {
+                                Some(base) if base > 0 => target / base as f64,
+                                _ => {
+                                    tracing::warn!(
+                                        "Recipe '{}' has no numeric servings metadata; \
+                                         treating {} servings as a raw multiplier",
+                                        ref_display,
+                                        target
+                                    );
+                                    target
+                                }
+                            }
+                        }
+                        (Some(target), Some(unit)) => match &info.default_yield {
+                            Some((base, base_unit)) if base_unit == unit && *base > 0.0 => {
+                                target / base
+                            }
+                            Some((_, base_unit)) => {
+                                tracing::warn!(
+                                    "Recipe '{}' yield unit '{}' does not match \
+                                     reference unit '{}'; treating {} as a raw multiplier",
+                                    ref_display,
+                                    base_unit,
+                                    unit,
+                                    target
+                                );
+                                target
+                            }
+                            None => {
+                                tracing::warn!(
+                                    "Recipe '{}' has no yield metadata to scale \
+                                     against '{}'; treating {} as a raw multiplier",
+                                    ref_display,
+                                    unit,
+                                    target
+                                );
+                                target
+                            }
+                        },
+                    }
+                }
+                None => 1.0,
+            };
+            let final_scale = recipe_factor * menu_scale;
+            let sub_refs = info.sub_refs;
 
             // Strip ./ prefix for storage (the format writer adds it back)
             let path = ref_display

--- a/src/server/handlers/shopping_list.rs
+++ b/src/server/handlers/shopping_list.rs
@@ -154,7 +154,7 @@ pub async fn shopping_list(
         // a long list — sort alphabetically (case-insensitive) so shoppers
         // can find items predictably.
         if category == "other" {
-            entries.sort_by(|(a, _), (b, _)| a.to_lowercase().cmp(&b.to_lowercase()));
+            entries.sort_by_key(|(a, _)| a.to_lowercase());
         }
 
         let mut shopping_items = Vec::new();

--- a/src/server/handlers/shopping_list.rs
+++ b/src/server/handlers/shopping_list.rs
@@ -435,15 +435,20 @@ pub struct AddMenuRequest {
 
 /// Information about a referenced recipe needed to convert a menu's
 /// `{target%unit}` into a storage multiplier for `.shopping-list`.
+#[derive(Default)]
 struct RecipeInfo {
     sub_refs: Vec<String>,
+    /// Numeric `servings` metadata. The cooklang API only exposes this as
+    /// `u32`, so fractional defaults like `servings: 1.5` appear as `None`
+    /// and fall back to raw-multiplier mode.
     default_servings: Option<u32>,
     /// Parsed `yield` metadata (value, unit) if present and well-formed,
     /// e.g. `yield: 500%ml` → `Some((500.0, "ml"))`.
     default_yield: Option<(f64, String)>,
 }
 
-/// Parse `"VALUE%UNIT"` (the only format `scale_to_yield` accepts) into its parts.
+/// Parse the `yield` metadata format `"VALUE%UNIT"` (e.g. `"500%ml"`) into
+/// its numeric value and unit.
 fn parse_yield(s: &str) -> Option<(f64, String)> {
     let (value, unit) = s.split_once('%')?;
     let value = value.trim().parse::<f64>().ok()?;
@@ -533,11 +538,7 @@ pub async fn add_menu_to_shopping_list(
                         ref_display,
                         e
                     );
-                    RecipeInfo {
-                        sub_refs: Vec::new(),
-                        default_servings: None,
-                        default_yield: None,
-                    }
+                    RecipeInfo::default()
                 }
             };
 
@@ -561,9 +562,14 @@ pub async fn add_menu_to_shopping_list(
                         _ => None,
                     };
                     match (value, q.unit()) {
+                        // Non-numeric quantity (e.g. `{some%servings}`): no
+                        // target to scale against, so use identity.
                         (None, _) => 1.0,
                         (Some(v), None) => v,
-                        (Some(target), Some("servings" | "serving")) => {
+                        (Some(target), Some(unit))
+                            if unit.eq_ignore_ascii_case("servings")
+                                || unit.eq_ignore_ascii_case("serving") =>
+                        {
                             match info.default_servings {
                                 Some(base) if base > 0 => target / base as f64,
                                 _ => {
@@ -578,7 +584,9 @@ pub async fn add_menu_to_shopping_list(
                             }
                         }
                         (Some(target), Some(unit)) => match &info.default_yield {
-                            Some((base, base_unit)) if base_unit == unit && *base > 0.0 => {
+                            Some((base, base_unit))
+                                if base_unit.eq_ignore_ascii_case(unit) && *base > 0.0 =>
+                            {
                                 target / base
                             }
                             Some((_, base_unit)) => {
@@ -637,4 +645,40 @@ pub async fn add_menu_to_shopping_list(
         })?;
 
     Ok(StatusCode::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_yield;
+
+    #[test]
+    fn parse_yield_basic() {
+        assert_eq!(parse_yield("500%ml"), Some((500.0, "ml".to_string())));
+    }
+
+    #[test]
+    fn parse_yield_decimal() {
+        assert_eq!(parse_yield("1.5%l"), Some((1.5, "l".to_string())));
+    }
+
+    #[test]
+    fn parse_yield_trims_whitespace() {
+        assert_eq!(parse_yield(" 250 % g "), Some((250.0, "g".to_string())));
+    }
+
+    #[test]
+    fn parse_yield_missing_unit() {
+        assert_eq!(parse_yield("500%"), None);
+        assert_eq!(parse_yield("500"), None);
+    }
+
+    #[test]
+    fn parse_yield_missing_value() {
+        assert_eq!(parse_yield("%ml"), None);
+    }
+
+    #[test]
+    fn parse_yield_non_numeric_value() {
+        assert_eq!(parse_yield("abc%ml"), None);
+    }
 }


### PR DESCRIPTION
## Summary

- `@./Recipe{3%servings}` in a `.menu` was being stored as a raw `{3}` multiplier in `.shopping-list`, so a 2-serving recipe was scaled to 6 servings instead of 3.
- Fix interprets the reference unit per the [Cooklang spec](https://github.com/cooklang/spec/blob/main/conventions.md#scaling-referenced-recipes):
  - no unit → raw multiplier
  - `%servings` → `target / default_servings`
  - other unit → `target / default_yield_value` (unit must match the recipe's `yield` metadata)
- Falls back to the old raw-multiplier behaviour with a warning when the referenced recipe is missing metadata or the unit doesn't match.

## Test plan

- [x] `cargo build`, `cargo clippy`, `cargo fmt --check`, `cargo test --lib` all clean
- [ ] Manual: add a menu referencing `@./Salads/Boring{3%servings}` (where `Boring.cook` has `servings: 2`) to the shopping list via the web UI and confirm `.shopping-list` stores `{1.5}` and the generated list shows 3-serving quantities
- [ ] Manual: menu reference with yield unit (e.g. `@./sauces/hollandaise{150%ml}` against `yield: 500%ml`) scales to 0.3×
- [ ] Manual: unitless `@./Recipe{2}` still stores `{2}` and scales ×2
- [ ] Note: existing entries in an already-populated `.shopping-list` keep the old (wrong) multipliers — re-add the menu to regenerate