### PR TITLE
fix: resolve menu recipe references from collection root in CLI

### DIFF
--- a/src/shopping_list.rs
+++ b/src/shopping_list.rs
@@ -247,61 +247,11 @@ pub fn run(ctx: &Context, args: ShoppingListArgs) -> Result<()> {
     let ignore_references = args.ignore_references;
 
     for entry in expanded_recipes {
-        // Determine the base path for this entry
-        // If the entry is an absolute path or relative path to a file,
-        // use its parent directory as the base for resolving references
-        let entry_without_scaling = entry.split(':').next().unwrap_or(&entry);
-        let entry_path = Utf8PathBuf::from(entry_without_scaling);
-
-        // Check if this is a file path (contains '/' or starts with './')
-        let (actual_entry, base_path) = if entry_without_scaling.contains('/') {
-            // This looks like a file path, not just a recipe name
-            let full_path = if entry_path.is_absolute() {
-                entry_path.clone()
-            } else {
-                // Clean up the path by removing ./ prefix if present
-                let clean_entry = entry_without_scaling
-                    .strip_prefix("./")
-                    .unwrap_or(entry_without_scaling);
-                ctx.base_path().join(clean_entry)
-            };
-
-            if full_path.exists() && full_path.is_file() {
-                // File exists, use its parent directory as base
-                let base = full_path
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(|| ctx.base_path().clone());
-
-                // Convert to just the filename for the recipe lookup
-                let filename = full_path
-                    .file_name()
-                    .map(|n| n.to_string())
-                    .unwrap_or_else(|| entry_without_scaling.to_string());
-
-                // Preserve scaling if present
-                let actual = if entry.contains(':') {
-                    format!("{}:{}", filename, entry.split(':').nth(1).unwrap())
-                } else {
-                    filename
-                };
-
-                (actual, base)
-            } else {
-                // File doesn't exist, but still treat as path
-                // This will fail with a better error message
-                (entry.to_string(), ctx.base_path().clone())
-            }
-        } else {
-            // This is just a recipe name, use as-is
-            (entry.to_string(), ctx.base_path().clone())
-        };
-
         extract_ingredients(
-            &actual_entry,
+            &entry,
             &mut list,
             &mut seen,
-            &base_path,
+            ctx.base_path(),
             PARSER.converter(),
             ignore_references,
             None, // CLI always includes all references


### PR DESCRIPTION
## Summary

- Fix CLI `shopping-list` command failing to find recipes referenced in menu files located in subdirectories (e.g. `cook shopping-list "Plans/3 Day Plan VII.menu"`)
- The CLI was setting `base_path` to the menu file's parent directory, so references like `./Breakfast/Oats` were resolved relative to `Plans/` instead of the recipe collection root
- Remove the path-splitting logic and always use `ctx.base_path()`, matching the server's behavior

## Test plan

- [ ] Run `cook shopping-list "Plans/3 Day Plan VII.menu"` from the recipes directory — should resolve all recipe references
- [ ] Run `cook shopping-list recipe.cook` for a recipe in the current directory — still works
- [ ] Verify server UI shopping list continues to work as before
- [ ] `cargo test` passes