### PR TITLE
fix: don't treat Windows drive-letter colons as scaling delimiter

### DIFF
--- a/src/recipe/read.rs
+++ b/src/recipe/read.rs
@@ -29,7 +29,7 @@
 // SOFTWARE.
 
 use anyhow::{Context as _, Result};
-use clap::{Args, CommandFactory, ValueEnum};
+use clap::{Args, ValueEnum};
 use std::io::Read;
 
 use camino::Utf8PathBuf;
@@ -99,17 +99,7 @@ pub fn run(ctx: &Context, args: ReadArgs) -> Result<()> {
 
     let (recipe, title) = if let Some(query) = args.input.recipe {
         let (name, scaling_factor) = split_recipe_name_and_scaling_factor(query.as_str())
-            .map(|(name, scaling_factor)| {
-                let target = scaling_factor.parse::<f64>().unwrap_or_else(|err| {
-                    let mut cmd = crate::args::CliArgs::command();
-                    cmd.error(
-                        clap::error::ErrorKind::InvalidValue,
-                        format!("Invalid scaling target for '{name}': {err}. Use a number value after : to specify a scaling factor."),
-                    )
-                    .exit()
-                });
-                (name, Some(target))
-            })
+            .map(|(name, factor)| (name, Some(factor)))
             .unwrap_or((query.as_str(), None));
 
         if let Some(scaling_factor) = scaling_factor {

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,7 +1,7 @@
 use crate::util::split_recipe_name_and_scaling_factor;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use cooklang_reports::{config::Config, render_template_with_config};
 use std::{fs, path::PathBuf};
 use tracing::warn;
@@ -66,19 +66,8 @@ pub fn run(ctx: &crate::Context, args: ReportArgs) -> Result<()> {
     warn!("⚠️  The report command is a prototype feature and will change in future versions.");
 
     // Split recipe name and scaling factor
-    let (recipe_name, scaling_factor) = split_recipe_name_and_scaling_factor(&args.recipe)
-        .map(|(name, factor)| {
-            let scale = factor.parse::<f64>().unwrap_or_else(|err| {
-                let mut cmd = crate::args::CliArgs::command();
-                cmd.error(
-                    clap::error::ErrorKind::InvalidValue,
-                    format!("Invalid scaling factor for '{name}': {err}"),
-                )
-                .exit()
-            });
-            (name, scale)
-        })
-        .unwrap_or((&args.recipe, 1.0));
+    let (recipe_name, scaling_factor) =
+        split_recipe_name_and_scaling_factor(&args.recipe).unwrap_or((&args.recipe, 1.0));
 
     // Read the recipe file
     let recipe = fs::read_to_string(recipe_name)

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -38,7 +38,6 @@ pub mod format;
 
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use clap::CommandFactory;
 use cooklang::{
     ingredient_list::IngredientList, quantity::Value, Converter, CooklangParser, Extensions, Recipe,
 };
@@ -113,8 +112,10 @@ where
     Ok(())
 }
 
-pub fn split_recipe_name_and_scaling_factor(query: &str) -> Option<(&str, &str)> {
-    query.trim().rsplit_once(RECIPE_SCALING_DELIMITER)
+pub fn split_recipe_name_and_scaling_factor(query: &str) -> Option<(&str, f64)> {
+    let (name, factor) = query.trim().rsplit_once(RECIPE_SCALING_DELIMITER)?;
+    let factor = factor.parse::<f64>().ok()?;
+    Some((name, factor))
 }
 
 /// Resolves a path to an absolute path. If the input path is already absolute,
@@ -171,19 +172,8 @@ pub fn extract_ingredients(
     seen.insert(entry.to_string(), seen.len());
 
     // split into name and servings
-    let (name, scaling_factor) = split_recipe_name_and_scaling_factor(entry)
-        .map(|(name, scaling_factor)| {
-            let target = scaling_factor.parse::<f64>().unwrap_or_else(|err| {
-                let mut cmd = crate::args::CliArgs::command();
-                cmd.error(
-                    clap::error::ErrorKind::InvalidValue,
-                    format!("Invalid scaling target for '{name}': {err}"),
-                )
-                .exit()
-            });
-            (name, target)
-        })
-        .unwrap_or((entry, 1.0));
+    let (name, scaling_factor) =
+        split_recipe_name_and_scaling_factor(entry).unwrap_or((entry, 1.0));
 
     let recipe_entry =
         get_recipe(base_path, name).with_context(|| format!("Failed to find recipe '{name}'"))?;
@@ -399,4 +389,47 @@ pub fn get_recipe(base_path: &Utf8PathBuf, name: &str) -> Result<RecipeEntry> {
         vec![base_path.clone()],
         clean_name.into(),
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_recipe_with_numeric_scaling_factor() {
+        assert_eq!(
+            split_recipe_name_and_scaling_factor("recipe.cook:2"),
+            Some(("recipe.cook", 2.0))
+        );
+    }
+
+    #[test]
+    fn splits_recipe_with_decimal_scaling_factor() {
+        assert_eq!(
+            split_recipe_name_and_scaling_factor("recipe.cook:1.5"),
+            Some(("recipe.cook", 1.5))
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_colon() {
+        assert_eq!(split_recipe_name_and_scaling_factor("recipe.cook"), None);
+    }
+
+    #[test]
+    fn returns_none_for_windows_absolute_path() {
+        // Regression for https://github.com/cooklang/cookcli/issues/335
+        assert_eq!(
+            split_recipe_name_and_scaling_factor(r"C:\test\recipe.cook"),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_when_right_side_is_not_numeric() {
+        assert_eq!(
+            split_recipe_name_and_scaling_factor("recipe.cook:abc"),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #335. On Windows, paths like `C:\test\recipe.cook` were being split on the drive-letter colon, producing the error `Invalid scaling factor for 'C': invalid float literal`.
- `split_recipe_name_and_scaling_factor` now only splits when the right side actually parses as `f64`, so drive-letter paths fall through unchanged. Returning `Option<(&str, f64)>` also let me drop the parse-and-abort logic in all three callers (`recipe read`, `report`, `extract_ingredients`).

## Behavioral note
A typo like `recipe.cook:abc` no longer surfaces as `Invalid scaling factor`; it now flows through and reports `Recipe not found: recipe.cook:abc`. I think that's clearer (the user gave a path; we report it doesn't exist), but happy to add an explicit "looks like a typo'd scaling factor" check if reviewers prefer.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (all existing tests + 5 new unit tests for the helper)
- [x] Manual smoke: `cook recipe read seed/Breakfast/Easy\ Pancakes.cook:2` still scales correctly
- [x] Manual smoke: `cook recipe read 'C:\test\recipe.cook'` now reports "Recipe not found" instead of the float-parse error