### PR TITLE
fix: default new recipe path to current folder

### DIFF
--- a/src/server/templates.rs
+++ b/src/server/templates.rs
@@ -59,6 +59,7 @@ pub struct RecipesTemplate {
     pub breadcrumbs: Vec<Breadcrumb>,
     pub items: Vec<RecipeItem>,
     pub todays_menu: Option<TodaysMenu>,
+    pub new_recipe_url: String,
     pub tr: Tr,
     pub prefix: String,
 }

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -167,12 +167,22 @@ async fn recipes_handler(
         crate::server::i18n::LOCALES.lookup(&lang, "recipes-title")
     };
 
+    let new_recipe_url = match &path {
+        Some(p) => format!(
+            "{}/new?filename={}%2F",
+            state.url_prefix,
+            urlencoding::encode(p)
+        ),
+        None => format!("{}/new", state.url_prefix),
+    };
+
     let template = RecipesTemplate {
         active: "recipes".to_string(),
         current_name,
         breadcrumbs,
         items,
         todays_menu,
+        new_recipe_url,
         tr: Tr::new(lang),
         prefix: state.url_prefix.clone(),
     };

--- a/templates/recipes.html
+++ b/templates/recipes.html
@@ -22,7 +22,7 @@
         <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-600 to-yellow-600 bg-clip-text text-transparent">
             {{ current_name }}
         </h1>
-        <a href="{{ prefix }}/new" class="px-4 py-2 bg-gradient-to-r from-orange-500 to-red-500 text-white rounded-lg hover:from-orange-600 hover:to-red-600 transition-all shadow-md flex items-center gap-2">
+        <a href="{{ new_recipe_url }}" class="px-4 py-2 bg-gradient-to-r from-orange-500 to-red-500 text-white rounded-lg hover:from-orange-600 hover:to-red-600 transition-all shadow-md flex items-center gap-2">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
             </svg>


### PR DESCRIPTION
## Summary
- Pre-populates the new recipe filename input with the current directory path when "+ New Recipe" is clicked from inside a folder
- Root listing keeps the existing plain `/new` link

Fixes #332

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` pass
- [x] From `/`, the button links to `/new` (no prefill)
- [x] From `/directory/Breakfast`, the button links to `/new?filename=Breakfast%2F` and the form input renders with `value="Breakfast/"`
- [x] Submitting the form with the prefilled value plus a recipe name creates the file in the expected folder