### PR TITLE
fix(server): recognize `duration` and `time required` as `time` aliases

### DIFF
--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -711,7 +711,9 @@ async fn recipe_page(
 
         Some(RecipeMetadata {
             servings: get_field("servings"),
-            time: get_field("time"),
+            time: get_field("time")
+                .or_else(|| get_field("duration"))
+                .or_else(|| get_field("time required")),
             difficulty: get_field("difficulty"),
             course: get_field("course"),
             prep_time: get_field("prep time")
@@ -1302,7 +1304,9 @@ async fn menu_page_handler(
 
         Some(RecipeMetadata {
             servings: get_field("servings"),
-            time: get_field("time"),
+            time: get_field("time")
+                .or_else(|| get_field("duration"))
+                .or_else(|| get_field("time required")),
             difficulty: get_field("difficulty"),
             course: get_field("course"),
             prep_time: get_field("prep time")


### PR DESCRIPTION
## Summary
- The Cooklang spec defines `time`, `duration`, and `time required` as aliases for the canonical `time` metadata key (see `cooklang-rs/src/metadata.rs:87`), but the server's recipe and menu pages only looked up the literal `time` key, so recipes using either alias rendered no time pill.
- Add fallback lookups for `duration` and `time required` in both `recipe_page` and the menu handler, mirroring the existing alias pattern used for `prep time` / `cook time`.

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` clean
- [x] Manually verified against `cook server` with three recipes (`time:`, `duration:`, `time required:`) — all three render the same `⏱️ <value>` pill, no duplication under custom metadata

Closes #320