### PR TITLE
feat(build): generate sitemap.xml with `cook build web --sitemap`

### DIFF
--- a/docs/superpowers/plans/2026-06-06-sitemap-static-site.md
+++ b/docs/superpowers/plans/2026-06-06-sitemap-static-site.md
@@ -1,0 +1,518 @@
+# Sitemap Generation for `cook build web` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Optionally emit a sitemaps.org-compliant `sitemap.xml` at the static-site output root when `cook build web --sitemap <URL>` is given.
+
+**Architecture:** A new `src/build/sitemap.rs` module with pure, unit-tested rendering helpers (`build_loc`, `xml_escape`, `format_lastmod`, `render_sitemap_xml`) plus thin tree-walking glue (`build_sitemap_entries`, `write_sitemap`) that mirrors the existing `index.rs` walk. `mod.rs` gains a `--sitemap` flag, validates it with the `url` crate, and calls the writer after the search index is built using the already-pruned tree.
+
+**Tech Stack:** Rust, clap (args), `url` (validation), `urlencoding` (percent-encode path segments), `chrono` (W3C date), `camino` (paths). Output via existing `writer::write_bytes`.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-sitemap-static-site-design.md`
+
+---
+
+### Task 1: Sitemap module — pure rendering core (TDD)
+
+Create the module with the data type and pure helpers, fully unit-tested. The
+tree-walking glue (`build_sitemap_entries`, `write_sitemap`) is added in Task 2
+together with the wiring, so the functions are exercised end-to-end then. Between
+this task and Task 2 the new functions are unused by non-test code, so
+`cargo build` will print `dead_code` warnings — that is expected and is cleared
+by Task 2. `cargo test` compiles the tests that use them, so tests pass.
+
+**Files:**
+- Create: `src/build/sitemap.rs`
+- Modify: `src/build/mod.rs:1-4` (add `mod sitemap;` to the module declarations)
+
+- [ ] **Step 1: Declare the module**
+
+In `src/build/mod.rs`, the top currently reads:
+
+```rust
+mod index;
+mod links;
+mod renderer;
+mod writer;
+```
+
+Change it to (keep alphabetical-ish grouping; add `sitemap`):
+
+```rust
+mod index;
+mod links;
+mod renderer;
+mod sitemap;
+mod writer;
+```
+
+- [ ] **Step 2: Write the module skeleton with the data type and the failing tests**
+
+Create `src/build/sitemap.rs` with the type, helper signatures (unimplemented
+bodies using `todo!()`), and the full test module:
+
+```rust
+use anyhow::Result;
+use camino::Utf8Path;
+use chrono::NaiveDate;
+
+/// One entry in the sitemap.
+///
+/// `relpath` is the page path relative to the output root, e.g.
+/// "recipe/Breakfast/Pancakes.html". The empty string represents the homepage
+/// and renders as `<base>/`.
+struct SitemapUrl {
+    relpath: String,
+    lastmod: Option<NaiveDate>,
+}
+
+/// XML-escape element text: `&`, `<`, `>`.
+fn xml_escape(s: &str) -> String {
+    todo!()
+}
+
+/// Percent-encode each `/`-separated path segment, preserving the separators.
+fn encode_path(relpath: &str) -> String {
+    todo!()
+}
+
+/// Build the `<loc>` text: trimmed base + "/" + encoded path, XML-escaped.
+/// The empty relpath yields `<base>/`.
+fn build_loc(base: &str, relpath: &str) -> String {
+    todo!()
+}
+
+/// Format a date as W3C `YYYY-MM-DD`.
+fn format_lastmod(date: NaiveDate) -> String {
+    todo!()
+}
+
+/// Render the full sitemap XML document.
+fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn escapes_xml_specials() {
+        assert_eq!(xml_escape("a & b < c > d"), "a &amp; b &lt; c &gt; d");
+    }
+
+    #[test]
+    fn encodes_spaces_per_segment_preserving_slashes() {
+        assert_eq!(
+            encode_path("recipe/Root Vegetables/Mash Up.html"),
+            "recipe/Root%20Vegetables/Mash%20Up.html"
+        );
+    }
+
+    #[test]
+    fn loc_trims_trailing_slash_on_base() {
+        assert_eq!(
+            build_loc("https://x.test/recipes/", "recipe/A.html"),
+            "https://x.test/recipes/recipe/A.html"
+        );
+        assert_eq!(
+            build_loc("https://x.test/recipes", "recipe/A.html"),
+            "https://x.test/recipes/recipe/A.html"
+        );
+    }
+
+    #[test]
+    fn loc_homepage_is_base_slash() {
+        assert_eq!(build_loc("https://x.test", ""), "https://x.test/");
+        assert_eq!(build_loc("https://x.test/", ""), "https://x.test/");
+    }
+
+    #[test]
+    fn loc_percent_encodes_ampersand_in_name() {
+        let loc = build_loc("https://x.test", "recipe/Mac & Cheese.html");
+        assert!(loc.contains("Mac%20%26%20Cheese"), "got: {loc}");
+        assert!(!loc.contains(" & "), "raw ampersand leaked: {loc}");
+    }
+
+    #[test]
+    fn formats_lastmod_w3c() {
+        assert_eq!(format_lastmod(date(2026, 6, 6)), "2026-06-06");
+        assert_eq!(format_lastmod(date(2026, 1, 2)), "2026-01-02");
+    }
+
+    #[test]
+    fn renders_well_formed_document() {
+        let entries = vec![
+            SitemapUrl { relpath: String::new(), lastmod: None },
+            SitemapUrl {
+                relpath: "recipe/Pancakes.html".to_string(),
+                lastmod: Some(date(2026, 6, 6)),
+            },
+        ];
+        let xml = render_sitemap_xml("https://x.test", &entries);
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"));
+        assert!(xml.contains("<loc>https://x.test/</loc>"));
+        assert!(xml.contains("<loc>https://x.test/recipe/Pancakes.html</loc>"));
+        assert!(xml.contains("<lastmod>2026-06-06</lastmod>"));
+        assert!(xml.trim_end().ends_with("</urlset>"));
+        // Homepage entry has no lastmod; recipe entry has exactly one.
+        assert_eq!(xml.matches("<lastmod>").count(), 1);
+        assert_eq!(xml.matches("<url>").count(), 2);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test -p cookcli sitemap::`
+Expected: compiles, tests panic with `not yet implemented` (`todo!()`).
+
+- [ ] **Step 4: Implement the pure helpers**
+
+Replace the four `todo!()` bodies:
+
+```rust
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn encode_path(relpath: &str) -> String {
+    relpath
+        .split('/')
+        .map(|seg| urlencoding::encode(seg).into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn build_loc(base: &str, relpath: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let loc = format!("{base}/{}", encode_path(relpath));
+    xml_escape(&loc)
+}
+
+fn format_lastmod(date: NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}
+```
+
+Note: `encode_path("")` returns `""` (a single empty segment), so
+`build_loc(base, "")` yields `"{base}/"` — the homepage. `urlencoding::encode`
+encodes a space as `%20` and `&` as `%26`, so no raw XML-special characters
+survive in the path; `xml_escape` then covers anything in `base`.
+
+- [ ] **Step 5: Implement `render_sitemap_xml`**
+
+```rust
+fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
+    let mut out = String::new();
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+    for entry in entries {
+        out.push_str("  <url>\n");
+        out.push_str(&format!("    <loc>{}</loc>\n", build_loc(base, &entry.relpath)));
+        if let Some(date) = entry.lastmod {
+            out.push_str(&format!("    <lastmod>{}</lastmod>\n", format_lastmod(date)));
+        }
+        out.push_str("  </url>\n");
+    }
+    out.push_str("</urlset>\n");
+    out
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p cookcli sitemap::`
+Expected: all sitemap tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/build/sitemap.rs src/build/mod.rs
+git commit -m "feat(build): add sitemap XML rendering core"
+```
+
+---
+
+### Task 2: Tree walk + wiring into `cook build web`
+
+Add the tree-walking glue and the `--sitemap` flag, then call it from `run_web`.
+This clears the dead-code warnings from Task 1 by putting every function to use.
+
+**Files:**
+- Modify: `src/build/sitemap.rs` (add `build_sitemap_entries` and `write_sitemap`)
+- Modify: `src/build/mod.rs:37-64` (add `sitemap` arg field), `:107-148` (validation + call + summary)
+
+- [ ] **Step 1: Add the tree-walk and writer glue to `sitemap.rs`**
+
+Append to `src/build/sitemap.rs` (before the `#[cfg(test)]` module). It walks the
+`RecipeTree` exactly like `index.rs::collect` / `walk_directories`: leaves are
+recipe/menu pages, non-leaves are directory pages. The homepage entry is pushed
+once at the top. `lastmod` comes from the node's on-disk `path` mtime
+(best-effort).
+
+```rust
+use cooklang_find::RecipeTree;
+
+/// Read a file's modification time as a local `NaiveDate`, best-effort.
+fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let datetime: chrono::DateTime<chrono::Local> = modified.into();
+    Some(datetime.date_naive())
+}
+
+/// Walk the recipe tree into a flat list of sitemap entries: the homepage, one
+/// per directory listing page, and one per recipe/menu page.
+fn build_sitemap_entries(tree: &RecipeTree) -> Vec<SitemapUrl> {
+    let mut out = vec![SitemapUrl { relpath: String::new(), lastmod: None }];
+    collect(tree, String::new(), &mut out);
+    out
+}
+
+fn collect(tree: &RecipeTree, prefix: String, out: &mut Vec<SitemapUrl>) {
+    for (name, child) in &tree.children {
+        if child.children.is_empty() {
+            let Some(recipe) = child.recipe.as_ref() else {
+                continue;
+            };
+            // URL path uses the on-disk file stem, not the tree key (which may
+            // be the title from metadata) — consistent with index.rs.
+            let stem = recipe
+                .file_name()
+                .as_deref()
+                .map(|f| {
+                    f.trim_end_matches(".cook")
+                        .trim_end_matches(".menu")
+                        .to_string()
+                })
+                .unwrap_or_else(|| name.clone());
+            let sub = if prefix.is_empty() {
+                stem
+            } else {
+                format!("{prefix}/{stem}")
+            };
+            let relpath = if recipe.is_menu() {
+                format!("menu/{sub}.html")
+            } else {
+                format!("recipe/{sub}.html")
+            };
+            out.push(SitemapUrl {
+                relpath,
+                lastmod: file_lastmod(&child.path),
+            });
+        } else {
+            let sub = if prefix.is_empty() {
+                name.to_string()
+            } else {
+                format!("{prefix}/{name}")
+            };
+            out.push(SitemapUrl {
+                relpath: format!("directory/{sub}.html"),
+                lastmod: None,
+            });
+            collect(child, sub, out);
+        }
+    }
+}
+
+/// Build and write `sitemap.xml` to the output root.
+pub fn write_sitemap(output: &Utf8Path, base: &str, tree: &RecipeTree) -> Result<()> {
+    let entries = build_sitemap_entries(tree);
+    let xml = render_sitemap_xml(base, &entries);
+    crate::build::writer::write_bytes(output, Utf8Path::new("sitemap.xml"), xml.as_bytes())
+}
+```
+
+- [ ] **Step 2: Confirm it still compiles and tests pass**
+
+Run: `cargo test -p cookcli sitemap::`
+Expected: PASS (the existing pure-function tests still pass; new glue compiles).
+
+- [ ] **Step 3: Add the `--sitemap` flag to `WebBuildArgs`**
+
+In `src/build/mod.rs`, the `WebBuildArgs` struct currently ends with the `lang`
+field (around lines 57-64). Add a new field after `lang`:
+
+```rust
+    /// UI language for the generated site (default: en-US)
+    ///
+    /// Accepts a BCP-47 tag like `de-DE`, or a bare language code like `de`
+    /// that matches a supported region. Supported: en-US, de-DE, nl-NL,
+    /// fr-FR, es-ES, eu-ES, sv-SE.
+    #[arg(long, value_parser = parse_lang_arg)]
+    pub lang: Option<LanguageIdentifier>,
+
+    /// Full base URL of the deployed site to generate a sitemap.xml
+    ///
+    /// When set (e.g. https://recipes.example.com or
+    /// https://example.com/recipes), writes a sitemaps.org-compliant
+    /// sitemap.xml at the output root listing every page with absolute URLs.
+    /// This is the complete URL prefix (scheme + host + optional subpath) and
+    /// is independent of --base-url. Omit it to skip sitemap generation.
+    #[arg(long)]
+    pub sitemap: Option<String>,
+```
+
+- [ ] **Step 4: Validate the URL and write the sitemap in `run_web`**
+
+In `src/build/mod.rs`, locate the block in `run_web` that writes the search
+index (currently lines ~137-144):
+
+```rust
+    let entries = index::build_search_index(&tree);
+    let entry_count = entries.len();
+    let json = serde_json::to_string(&entries)?;
+    writer::write_bytes(
+        &output,
+        camino::Utf8Path::new("static/search-index.json"),
+        json.as_bytes(),
+    )?;
+```
+
+Immediately after that block (before the final `println!`), add:
+
+```rust
+    let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
+        let parsed = url::Url::parse(base)
+            .with_context(|| format!("Invalid --sitemap URL: {base}"))?;
+        if parsed.cannot_be_a_base() || parsed.host().is_none() {
+            bail!("--sitemap must be an absolute URL with a host, e.g. https://recipes.example.com");
+        }
+        sitemap::write_sitemap(&output, base, &tree)?;
+        true
+    } else {
+        false
+    };
+```
+
+- [ ] **Step 5: Update the summary line to mention the sitemap**
+
+The final `println!` in `run_web` currently reads (lines ~146-148):
+
+```rust
+    println!(
+        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries"
+    );
+    Ok(())
+```
+
+Replace it with:
+
+```rust
+    let sitemap_note = if sitemap_written { ", sitemap.xml" } else { "" };
+    println!(
+        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries{sitemap_note}"
+    );
+    Ok(())
+```
+
+- [ ] **Step 6: Build and run the full test suite**
+
+Run: `cargo test -p cookcli`
+Expected: PASS, no compile errors, no remaining `dead_code` warnings from `sitemap.rs`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/build/sitemap.rs src/build/mod.rs
+git commit -m "feat(build): generate sitemap.xml with --sitemap flag"
+```
+
+---
+
+### Task 3: Manual end-to-end verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build a site with a sitemap against the seed recipes**
+
+Run:
+
+```bash
+cargo run -- build web /tmp/cooksite --base-path ./seed --sitemap https://recipes.example.com
+```
+
+Expected: the summary line ends with `, sitemap.xml`, and
+`/tmp/cooksite/sitemap.xml` exists.
+
+- [ ] **Step 2: Inspect the sitemap**
+
+Run:
+
+```bash
+head -20 /tmp/cooksite/sitemap.xml
+```
+
+Expected: starts with the XML prolog and `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+contains `<loc>https://recipes.example.com/</loc>` for the homepage, plus
+`<loc>` entries under `https://recipes.example.com/recipe/...` and
+`https://recipes.example.com/directory/...`, with `<lastmod>YYYY-MM-DD</lastmod>`
+on recipe entries.
+
+- [ ] **Step 3: Verify it is well-formed XML**
+
+Run:
+
+```bash
+xmllint --noout /tmp/cooksite/sitemap.xml && echo "well-formed"
+```
+
+Expected: prints `well-formed` (no parser errors). If `xmllint` is unavailable,
+skip this step.
+
+- [ ] **Step 4: Verify omitting the flag skips the sitemap**
+
+Run:
+
+```bash
+rm -rf /tmp/cooksite2 && cargo run -- build web /tmp/cooksite2 --base-path ./seed
+test ! -e /tmp/cooksite2/sitemap.xml && echo "no sitemap (correct)"
+```
+
+Expected: prints `no sitemap (correct)` and the summary line does NOT mention sitemap.
+
+- [ ] **Step 5: Verify an invalid URL is rejected**
+
+Run:
+
+```bash
+cargo run -- build web /tmp/cooksite3 --base-path ./seed --sitemap not-a-url; echo "exit: $?"
+```
+
+Expected: a clear error mentioning the invalid `--sitemap` URL and a non-zero exit code.
+
+---
+
+### Task 4: Pre-PR checks
+
+**Files:** none.
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt`
+Expected: no diff / clean.
+
+- [ ] **Step 2: Lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings or errors.
+
+- [ ] **Step 3: Test**
+
+Run: `cargo test`
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit any formatting changes (if any)**
+
+```bash
+git add -A
+git commit -m "chore: fmt" || echo "nothing to commit"
+```
+```

--- a/docs/superpowers/specs/2026-06-06-sitemap-static-site-design.md
+++ b/docs/superpowers/specs/2026-06-06-sitemap-static-site-design.md
@@ -1,0 +1,132 @@
+# Sitemap generation for `cook build web`
+
+Date: 2026-06-06
+Issue: https://github.com/cooklang/cookcli/issues/346
+
+## Goal
+
+Optionally generate a `sitemap.xml` (per the [sitemaps.org protocol](https://www.sitemaps.org/protocol.html))
+when building the static site with `cook build web`, so the generated site is
+more discoverable by search engines.
+
+## Background
+
+`cook build web` (added in #344, nested under `build` in #348) renders recipes
+to a self-contained static site. The output tree contains:
+
+- `index.html` — root recipe listing
+- `directory/<sub>.html` — one per non-leaf directory node
+- `recipe/<sub>.html` and `menu/<sub>.html` — one per recipe / menu leaf
+- `static/...` assets, `api/static/...` images, `recipe/<sub>.cook` sources
+- `static/search-index.json`
+
+The sitemaps.org protocol requires each `<loc>` to be a **fully-qualified
+absolute URL** (scheme + host). The existing `--base-url` flag is only a *path*
+prefix for internal links (e.g. `/recipes/`) and cannot supply the domain, so a
+new input is required.
+
+## Interface
+
+A new opt-in flag on `WebBuildArgs`:
+
+```
+--sitemap <URL>    Full base URL of the deployed site
+                   (e.g. https://recipes.example.com or https://example.com/recipes).
+                   When set, writes sitemap.xml at the output root listing all
+                   pages with absolute URLs.
+```
+
+- The value is the **complete base URL prefix** (origin + optional subpath).
+  Sitemap entry URLs are formed as `<sitemap>/<relpath>`. This mirrors the
+  `--base` argument of the `static-sitemap-cli` tool referenced in the issue:
+  one value carries scheme + host + subpath.
+- It is **independent of `--base-url`** (which only controls internal link
+  prefixes within pages). The two can be combined freely.
+- Validated with the `url` crate. A non-absolute / unparseable URL is a hard
+  error (`bail!`) with a clear message, so users never get a silently broken
+  sitemap.
+- When omitted, **no sitemap is produced** — no change to existing behavior.
+
+## Module: `src/build/sitemap.rs`
+
+Data:
+
+```rust
+struct SitemapUrl {
+    relpath: String,                  // e.g. "recipe/Breakfast/Pancakes.html"; "" for the homepage
+    lastmod: Option<chrono::NaiveDate>,
+}
+```
+
+Functions:
+
+- `build_sitemap_entries(tree: &RecipeTree, source: &Utf8Path) -> Vec<SitemapUrl>`
+  Walks the `RecipeTree` with the same traversal shape as
+  `index.rs::build_search_index` / `walk_directories`, producing:
+  - the homepage → `relpath = ""` (rendered as `<base>/`), no `lastmod`
+  - each non-leaf node → `directory/<sub>.html`, no `lastmod`
+  - each recipe/menu leaf → `recipe/<sub>.html` or `menu/<sub>.html`, with
+    `lastmod` from the on-disk `.cook`/`.menu` source file's modification time
+    (`std::fs::metadata().modified()`), converted to a local `NaiveDate`. If the
+    mtime cannot be read, `lastmod` is `None` (best-effort, never fatal).
+  Uses the on-disk file stem (not the tree key, which may be the metadata title),
+  consistent with `index.rs` and `walk_recipes`.
+
+- `render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String`
+  Builds the XML document:
+  - `<?xml version="1.0" encoding="UTF-8"?>`
+  - `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`
+  - one `<url>` per entry with:
+    - `<loc>`: `base` with any trailing slash trimmed, joined to the relpath.
+      Each path **segment** is percent-encoded with `urlencoding::encode`
+      (slashes between segments preserved), then the whole `<loc>` text is
+      XML-escaped (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`). The homepage
+      relpath `""` yields `<base>/`.
+    - `<lastmod>` (only when present): `YYYY-MM-DD`.
+
+- `write_sitemap(output: &Utf8Path, base: &str, tree: &RecipeTree, source: &Utf8Path) -> Result<()>`
+  Ties the above together and writes `sitemap.xml` to the output root via
+  `writer::write_bytes`.
+
+## Wiring in `mod.rs`
+
+- Add `sitemap: Option<String>` to `WebBuildArgs` (with the doc comment above).
+- Declare `mod sitemap;`.
+- In `run_web`, after the search index is written (reusing the already-pruned
+  `tree`):
+  - if `args.sitemap` is `Some(base)`:
+    - validate with `url::Url::parse(base)`; `bail!` on error or non-absolute
+      (no scheme/host).
+    - call `sitemap::write_sitemap(&output, base, &tree, &source)`.
+  - reflect it in the final summary line (e.g. append `, sitemap` when written).
+
+## Edge cases & decisions
+
+- **Homepage URL**: emitted as `<base>/` (canonical homepage), not
+  `<base>/index.html`. Static hosts serve `index.html` at the directory root.
+- **All HTML pages included**: index, directory listings, recipe and menu pages
+  (per design decision). `.cook` sources, images, JSON index, and static assets
+  are not page content and are excluded.
+- **Escaping**: per-segment percent-encoding handles spaces/Unicode in recipe
+  names; XML-escaping handles `&`/`<`/`>` in the resulting URL.
+- **Pruned tree**: the same pruned tree used for rendering is passed in, so a
+  `_site` output nested inside the source directory is not listed.
+- **lastmod is best-effort**: a missing/unreadable mtime omits `<lastmod>` for
+  that entry rather than failing the build.
+
+## Testing (unit tests in `sitemap.rs`)
+
+- `render_sitemap_xml` produces a well-formed document: XML prolog, `urlset`
+  with the correct `xmlns`, one `<url>`/`<loc>` per entry.
+- `<loc>` joins base + relpath correctly, with the homepage rendered as
+  `<base>/`.
+- Base URL with and without a trailing slash produce identical `<loc>` values.
+- A relpath segment containing a space is percent-encoded.
+- A name containing `&` is XML-escaped in the output.
+- `<lastmod>` is rendered as `YYYY-MM-DD` when present and omitted when absent.
+
+## Out of scope
+
+- `changefreq` / `priority` hints (optional in the protocol; omitted — YAGNI).
+- Sitemap index files / 50k-URL splitting (not needed at recipe-collection scale).
+- `robots.txt` generation.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -155,8 +155,8 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     )?;
 
     let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
-        let parsed = url::Url::parse(base)
-            .with_context(|| format!("Invalid --sitemap URL: {base}"))?;
+        let parsed =
+            url::Url::parse(base).with_context(|| format!("Invalid --sitemap URL: {base}"))?;
         if parsed.host().is_none() || !matches!(parsed.scheme(), "http" | "https") {
             bail!("--sitemap must be an absolute http(s) URL with a host, e.g. https://recipes.example.com");
         }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,6 +1,7 @@
 mod index;
 mod links;
 mod renderer;
+mod sitemap;
 mod writer;
 
 use crate::server::language::{parse_supported_language, EN_US};

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -118,6 +118,21 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     let lang = args.lang.clone().unwrap_or(EN_US);
     let base_url = args.base_url.as_deref();
 
+    // Validate the sitemap URL up front so a typo fails fast, before spending
+    // time rendering the whole site. The actual sitemap is written at the end.
+    let sitemap_base = args.sitemap.as_deref();
+    if let Some(base) = sitemap_base {
+        let parsed =
+            url::Url::parse(base).with_context(|| format!("Invalid --sitemap URL: {base}"))?;
+        if parsed.host().is_none()
+            || !matches!(parsed.scheme(), "http" | "https")
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            bail!("--sitemap must be an absolute http(s) URL with a host and no query or fragment, e.g. https://recipes.example.com");
+        }
+    }
+
     renderer::render_index(&source, &output, base_url, &lang)?;
 
     let mut tree = cooklang_find::build_tree(&source)
@@ -154,16 +169,8 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
         json.as_bytes(),
     )?;
 
-    let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
-        let parsed =
-            url::Url::parse(base).with_context(|| format!("Invalid --sitemap URL: {base}"))?;
-        if parsed.host().is_none()
-            || !matches!(parsed.scheme(), "http" | "https")
-            || parsed.query().is_some()
-            || parsed.fragment().is_some()
-        {
-            bail!("--sitemap must be an absolute http(s) URL with a host and no query or fragment, e.g. https://recipes.example.com");
-        }
+    // The URL was already validated near the top of run_web.
+    let sitemap_written = if let Some(base) = sitemap_base {
         sitemap::write_sitemap(&output, base, &tree)?;
         true
     } else {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -62,6 +62,16 @@ pub struct WebBuildArgs {
     /// fr-FR, es-ES, eu-ES, sv-SE.
     #[arg(long, value_parser = parse_lang_arg)]
     pub lang: Option<LanguageIdentifier>,
+
+    /// Full base URL of the deployed site to generate a sitemap.xml
+    ///
+    /// When set (e.g. https://recipes.example.com or
+    /// https://example.com/recipes), writes a sitemaps.org-compliant
+    /// sitemap.xml at the output root listing every page with absolute URLs.
+    /// This is the complete URL prefix (scheme + host + optional subpath) and
+    /// is independent of --base-url. Omit it to skip sitemap generation.
+    #[arg(long)]
+    pub sitemap: Option<String>,
 }
 
 fn parse_lang_arg(s: &str) -> Result<LanguageIdentifier, String> {
@@ -144,8 +154,21 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
         json.as_bytes(),
     )?;
 
+    let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
+        let parsed = url::Url::parse(base)
+            .with_context(|| format!("Invalid --sitemap URL: {base}"))?;
+        if parsed.cannot_be_a_base() || parsed.host().is_none() {
+            bail!("--sitemap must be an absolute URL with a host, e.g. https://recipes.example.com");
+        }
+        sitemap::write_sitemap(&output, base, &tree)?;
+        true
+    } else {
+        false
+    };
+
+    let sitemap_note = if sitemap_written { ", sitemap.xml" } else { "" };
     println!(
-        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries"
+        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries{sitemap_note}"
     );
     Ok(())
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -157,8 +157,12 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
         let parsed =
             url::Url::parse(base).with_context(|| format!("Invalid --sitemap URL: {base}"))?;
-        if parsed.host().is_none() || !matches!(parsed.scheme(), "http" | "https") {
-            bail!("--sitemap must be an absolute http(s) URL with a host, e.g. https://recipes.example.com");
+        if parsed.host().is_none()
+            || !matches!(parsed.scheme(), "http" | "https")
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            bail!("--sitemap must be an absolute http(s) URL with a host and no query or fragment, e.g. https://recipes.example.com");
         }
         sitemap::write_sitemap(&output, base, &tree)?;
         true

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -157,8 +157,8 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     let sitemap_written = if let Some(base) = args.sitemap.as_deref() {
         let parsed = url::Url::parse(base)
             .with_context(|| format!("Invalid --sitemap URL: {base}"))?;
-        if parsed.cannot_be_a_base() || parsed.host().is_none() {
-            bail!("--sitemap must be an absolute URL with a host, e.g. https://recipes.example.com");
+        if parsed.host().is_none() || !matches!(parsed.scheme(), "http" | "https") {
+            bail!("--sitemap must be an absolute http(s) URL with a host, e.g. https://recipes.example.com");
         }
         sitemap::write_sitemap(&output, base, &tree)?;
         true

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use camino::Utf8Path;
 use chrono::NaiveDate;
+use cooklang_find::RecipeTree;
 
 /// One entry in the sitemap.
 ///
@@ -57,8 +58,6 @@ fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
     out.push_str("</urlset>\n");
     out
 }
-
-use cooklang_find::RecipeTree;
 
 /// Read a file's modification time as a local `NaiveDate`, best-effort.
 fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -65,10 +65,14 @@ fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
     out
 }
 
-/// Read a file's modification time as a local `NaiveDate`, best-effort.
+/// Read a file's modification time as a UTC `NaiveDate`, best-effort.
+///
+/// UTC (rather than the local timezone) keeps `<lastmod>` reproducible across
+/// machines: the same source file yields the same date regardless of where the
+/// site is built.
 fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
-    let datetime: chrono::DateTime<chrono::Local> = modified.into();
+    let datetime: chrono::DateTime<chrono::Utc> = modified.into();
     Some(datetime.date_naive())
 }
 
@@ -142,10 +146,15 @@ fn collect(tree: &RecipeTree, prefix: String, output: &Utf8Path, out: &mut Vec<S
             } else {
                 format!("{prefix}/{name}")
             };
-            out.push(SitemapUrl {
-                relpath: format!("directory/{sub}.html"),
-                lastmod: None,
-            });
+            let relpath = format!("directory/{sub}.html");
+            // List the directory page only if it was written, but always recurse:
+            // a missing directory page doesn't mean its recipes are missing.
+            if output.join(page_file(&relpath)).exists() {
+                out.push(SitemapUrl {
+                    relpath,
+                    lastmod: None,
+                });
+            }
             collect(child, sub, output, out);
         }
     }
@@ -164,6 +173,45 @@ mod tests {
 
     fn date(y: i32, m: u32, d: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn build_entries_filters_missing_pages_and_sorts() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let src = TempDir::new().unwrap();
+        let out = TempDir::new().unwrap();
+        let src_root = Utf8Path::from_path(src.path()).unwrap();
+        let out_root = Utf8Path::from_path(out.path()).unwrap();
+
+        // Source recipes: one nested under a directory, one at the root.
+        fs::create_dir_all(src_root.join("Breakfast")).unwrap();
+        fs::write(src_root.join("Breakfast/Pancakes.cook"), "Mix @flour{1}.\n").unwrap();
+        fs::write(src_root.join("Soup.cook"), "Boil @water{1}.\n").unwrap();
+
+        let tree = cooklang_find::build_tree(src_root).unwrap();
+
+        // Simulate the render pass writing the homepage, the directory page, and
+        // Pancakes — but NOT Soup (e.g. it failed to render).
+        fs::write(out_root.join("index.html"), "x").unwrap();
+        fs::create_dir_all(out_root.join("recipe/Breakfast")).unwrap();
+        fs::write(out_root.join("recipe/Breakfast/Pancakes.html"), "x").unwrap();
+        fs::create_dir_all(out_root.join("directory")).unwrap();
+        fs::write(out_root.join("directory/Breakfast.html"), "x").unwrap();
+
+        let entries = build_sitemap_entries(&tree, out_root);
+        let paths: Vec<&str> = entries.iter().map(|e| e.relpath.as_str()).collect();
+
+        // Homepage first, then sorted; Soup is excluded because no file was written.
+        assert_eq!(
+            paths,
+            vec![
+                "",
+                "directory/Breakfast.html",
+                "recipe/Breakfast/Pancakes.html"
+            ]
+        );
     }
 
     #[test]

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -49,9 +49,15 @@ fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
     out.push_str("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
     for entry in entries {
         out.push_str("  <url>\n");
-        out.push_str(&format!("    <loc>{}</loc>\n", build_loc(base, &entry.relpath)));
+        out.push_str(&format!(
+            "    <loc>{}</loc>\n",
+            build_loc(base, &entry.relpath)
+        ));
         if let Some(date) = entry.lastmod {
-            out.push_str(&format!("    <lastmod>{}</lastmod>\n", format_lastmod(date)));
+            out.push_str(&format!(
+                "    <lastmod>{}</lastmod>\n",
+                format_lastmod(date)
+            ));
         }
         out.push_str("  </url>\n");
     }
@@ -69,7 +75,10 @@ fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {
 /// Walk the recipe tree into a flat list of sitemap entries: the homepage, one
 /// per directory listing page, and one per recipe/menu page.
 fn build_sitemap_entries(tree: &RecipeTree) -> Vec<SitemapUrl> {
-    let mut out = vec![SitemapUrl { relpath: String::new(), lastmod: None }];
+    let mut out = vec![SitemapUrl {
+        relpath: String::new(),
+        lastmod: None,
+    }];
     collect(tree, String::new(), &mut out);
     out
 }
@@ -182,7 +191,10 @@ mod tests {
     #[test]
     fn renders_well_formed_document() {
         let entries = vec![
-            SitemapUrl { relpath: String::new(), lastmod: None },
+            SitemapUrl {
+                relpath: String::new(),
+                lastmod: None,
+            },
             SitemapUrl {
                 relpath: "recipe/Pancakes.html".to_string(),
                 lastmod: Some(date(2026, 6, 6)),

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -74,16 +74,34 @@ fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {
 
 /// Walk the recipe tree into a flat list of sitemap entries: the homepage, one
 /// per directory listing page, and one per recipe/menu page.
-fn build_sitemap_entries(tree: &RecipeTree) -> Vec<SitemapUrl> {
+///
+/// Only pages that were actually written under `output` are listed: the render
+/// pass skips recipes whose templates fail to build (warn + continue), so a
+/// purely tree-derived list could point at pages that don't exist. We run after
+/// rendering, so an on-disk existence check keeps the sitemap free of 404s.
+/// Entries are sorted by path so repeated builds produce a stable, diff-friendly
+/// file (the underlying tree iteration order is non-deterministic).
+fn build_sitemap_entries(tree: &RecipeTree, output: &Utf8Path) -> Vec<SitemapUrl> {
     let mut out = vec![SitemapUrl {
         relpath: String::new(),
         lastmod: None,
     }];
-    collect(tree, String::new(), &mut out);
+    collect(tree, String::new(), output, &mut out);
+    out.sort_by(|a, b| a.relpath.cmp(&b.relpath));
     out
 }
 
-fn collect(tree: &RecipeTree, prefix: String, out: &mut Vec<SitemapUrl>) {
+/// The on-disk file backing a page entry, relative to `output`
+/// (the homepage's empty relpath maps to `index.html`).
+fn page_file(relpath: &str) -> &str {
+    if relpath.is_empty() {
+        "index.html"
+    } else {
+        relpath
+    }
+}
+
+fn collect(tree: &RecipeTree, prefix: String, output: &Utf8Path, out: &mut Vec<SitemapUrl>) {
     for (name, child) in &tree.children {
         if child.children.is_empty() {
             let Some(recipe) = child.recipe.as_ref() else {
@@ -110,6 +128,10 @@ fn collect(tree: &RecipeTree, prefix: String, out: &mut Vec<SitemapUrl>) {
             } else {
                 format!("recipe/{sub}.html")
             };
+            // Skip recipes the render pass failed to write (avoids dead links).
+            if !output.join(page_file(&relpath)).exists() {
+                continue;
+            }
             out.push(SitemapUrl {
                 relpath,
                 lastmod: file_lastmod(&child.path),
@@ -124,14 +146,14 @@ fn collect(tree: &RecipeTree, prefix: String, out: &mut Vec<SitemapUrl>) {
                 relpath: format!("directory/{sub}.html"),
                 lastmod: None,
             });
-            collect(child, sub, out);
+            collect(child, sub, output, out);
         }
     }
 }
 
 /// Build and write `sitemap.xml` to the output root.
 pub fn write_sitemap(output: &Utf8Path, base: &str, tree: &RecipeTree) -> Result<()> {
-    let entries = build_sitemap_entries(tree);
+    let entries = build_sitemap_entries(tree, output);
     let xml = render_sitemap_xml(base, &entries);
     crate::build::writer::write_bytes(output, Utf8Path::new("sitemap.xml"), xml.as_bytes())
 }

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -1,0 +1,134 @@
+#[allow(unused_imports)] // used by the next task's tree-walk glue
+use anyhow::Result;
+#[allow(unused_imports)] // used by the next task's tree-walk glue
+use camino::Utf8Path;
+use chrono::NaiveDate;
+
+/// One entry in the sitemap.
+///
+/// `relpath` is the page path relative to the output root, e.g.
+/// "recipe/Breakfast/Pancakes.html". The empty string represents the homepage
+/// and renders as `<base>/`.
+struct SitemapUrl {
+    relpath: String,
+    lastmod: Option<NaiveDate>,
+}
+
+/// XML-escape element text: `&`, `<`, `>`.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Percent-encode each `/`-separated path segment, preserving the separators.
+fn encode_path(relpath: &str) -> String {
+    relpath
+        .split('/')
+        .map(|seg| urlencoding::encode(seg).into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Build the `<loc>` text: trimmed base + "/" + encoded path, XML-escaped.
+/// The empty relpath yields `<base>/`.
+fn build_loc(base: &str, relpath: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let loc = format!("{base}/{}", encode_path(relpath));
+    xml_escape(&loc)
+}
+
+/// Format a date as W3C `YYYY-MM-DD`.
+fn format_lastmod(date: NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}
+
+/// Render the full sitemap XML document.
+fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
+    let mut out = String::new();
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
+    for entry in entries {
+        out.push_str("  <url>\n");
+        out.push_str(&format!("    <loc>{}</loc>\n", build_loc(base, &entry.relpath)));
+        if let Some(date) = entry.lastmod {
+            out.push_str(&format!("    <lastmod>{}</lastmod>\n", format_lastmod(date)));
+        }
+        out.push_str("  </url>\n");
+    }
+    out.push_str("</urlset>\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn escapes_xml_specials() {
+        assert_eq!(xml_escape("a & b < c > d"), "a &amp; b &lt; c &gt; d");
+    }
+
+    #[test]
+    fn encodes_spaces_per_segment_preserving_slashes() {
+        assert_eq!(
+            encode_path("recipe/Root Vegetables/Mash Up.html"),
+            "recipe/Root%20Vegetables/Mash%20Up.html"
+        );
+    }
+
+    #[test]
+    fn loc_trims_trailing_slash_on_base() {
+        assert_eq!(
+            build_loc("https://x.test/recipes/", "recipe/A.html"),
+            "https://x.test/recipes/recipe/A.html"
+        );
+        assert_eq!(
+            build_loc("https://x.test/recipes", "recipe/A.html"),
+            "https://x.test/recipes/recipe/A.html"
+        );
+    }
+
+    #[test]
+    fn loc_homepage_is_base_slash() {
+        assert_eq!(build_loc("https://x.test", ""), "https://x.test/");
+        assert_eq!(build_loc("https://x.test/", ""), "https://x.test/");
+    }
+
+    #[test]
+    fn loc_percent_encodes_ampersand_in_name() {
+        let loc = build_loc("https://x.test", "recipe/Mac & Cheese.html");
+        assert!(loc.contains("Mac%20%26%20Cheese"), "got: {loc}");
+        assert!(!loc.contains(" & "), "raw ampersand leaked: {loc}");
+    }
+
+    #[test]
+    fn formats_lastmod_w3c() {
+        assert_eq!(format_lastmod(date(2026, 6, 6)), "2026-06-06");
+        assert_eq!(format_lastmod(date(2026, 1, 2)), "2026-01-02");
+    }
+
+    #[test]
+    fn renders_well_formed_document() {
+        let entries = vec![
+            SitemapUrl { relpath: String::new(), lastmod: None },
+            SitemapUrl {
+                relpath: "recipe/Pancakes.html".to_string(),
+                lastmod: Some(date(2026, 6, 6)),
+            },
+        ];
+        let xml = render_sitemap_xml("https://x.test", &entries);
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"));
+        assert!(xml.contains("<loc>https://x.test/</loc>"));
+        assert!(xml.contains("<loc>https://x.test/recipe/Pancakes.html</loc>"));
+        assert!(xml.contains("<lastmod>2026-06-06</lastmod>"));
+        assert!(xml.trim_end().ends_with("</urlset>"));
+        assert_eq!(xml.matches("<lastmod>").count(), 1);
+        assert_eq!(xml.matches("<url>").count(), 2);
+    }
+}

--- a/src/build/sitemap.rs
+++ b/src/build/sitemap.rs
@@ -1,6 +1,4 @@
-#[allow(unused_imports)] // used by the next task's tree-walk glue
 use anyhow::Result;
-#[allow(unused_imports)] // used by the next task's tree-walk glue
 use camino::Utf8Path;
 use chrono::NaiveDate;
 
@@ -58,6 +56,76 @@ fn render_sitemap_xml(base: &str, entries: &[SitemapUrl]) -> String {
     }
     out.push_str("</urlset>\n");
     out
+}
+
+use cooklang_find::RecipeTree;
+
+/// Read a file's modification time as a local `NaiveDate`, best-effort.
+fn file_lastmod(path: &Utf8Path) -> Option<NaiveDate> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let datetime: chrono::DateTime<chrono::Local> = modified.into();
+    Some(datetime.date_naive())
+}
+
+/// Walk the recipe tree into a flat list of sitemap entries: the homepage, one
+/// per directory listing page, and one per recipe/menu page.
+fn build_sitemap_entries(tree: &RecipeTree) -> Vec<SitemapUrl> {
+    let mut out = vec![SitemapUrl { relpath: String::new(), lastmod: None }];
+    collect(tree, String::new(), &mut out);
+    out
+}
+
+fn collect(tree: &RecipeTree, prefix: String, out: &mut Vec<SitemapUrl>) {
+    for (name, child) in &tree.children {
+        if child.children.is_empty() {
+            let Some(recipe) = child.recipe.as_ref() else {
+                continue;
+            };
+            // URL path uses the on-disk file stem, not the tree key (which may
+            // be the title from metadata) — consistent with index.rs.
+            let stem = recipe
+                .file_name()
+                .as_deref()
+                .map(|f| {
+                    f.trim_end_matches(".cook")
+                        .trim_end_matches(".menu")
+                        .to_string()
+                })
+                .unwrap_or_else(|| name.clone());
+            let sub = if prefix.is_empty() {
+                stem
+            } else {
+                format!("{prefix}/{stem}")
+            };
+            let relpath = if recipe.is_menu() {
+                format!("menu/{sub}.html")
+            } else {
+                format!("recipe/{sub}.html")
+            };
+            out.push(SitemapUrl {
+                relpath,
+                lastmod: file_lastmod(&child.path),
+            });
+        } else {
+            let sub = if prefix.is_empty() {
+                name.to_string()
+            } else {
+                format!("{prefix}/{name}")
+            };
+            out.push(SitemapUrl {
+                relpath: format!("directory/{sub}.html"),
+                lastmod: None,
+            });
+            collect(child, sub, out);
+        }
+    }
+}
+
+/// Build and write `sitemap.xml` to the output root.
+pub fn write_sitemap(output: &Utf8Path, base: &str, tree: &RecipeTree) -> Result<()> {
+    let entries = build_sitemap_entries(tree);
+    let xml = render_sitemap_xml(base, &entries);
+    crate::build::writer::write_bytes(output, Utf8Path::new("sitemap.xml"), xml.as_bytes())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #346. Adds optional sitemap generation to the `cook build web` static-site generator.

- New opt-in **`--sitemap <URL>`** flag. When given the deployed site's full base URL (e.g. `https://recipes.example.com` or `https://example.com/recipes`), it writes a [sitemaps.org](https://www.sitemaps.org/protocol.html)-compliant `sitemap.xml` at the output root. Omitting it preserves existing behavior (no sitemap).
- Lists the homepage (`<base>/`), every directory listing page, and every recipe/menu page as **absolute URLs**, with path segments percent-encoded and a best-effort `<lastmod>` from each source file's modification time.
- The flag is independent of `--base-url` (which only controls internal link prefixes); `--sitemap` carries scheme + host + optional subpath.

### Robustness
- URL validation: must be an absolute `http(s)` URL with a host and no query/fragment, else a clear error and non-zero exit.
- Only pages actually written to disk are listed (the render pass skips recipes whose templates fail), so the sitemap never points at missing pages.
- Entries are sorted, so repeated builds produce a stable, diff-friendly file.

## Implementation

- New module `src/build/sitemap.rs`: pure, unit-tested rendering helpers (`xml_escape`, `encode_path`, `build_loc`, `format_lastmod`, `render_sitemap_xml`) plus tree-walk glue mirroring the existing `index.rs` pattern.
- Wiring in `src/build/mod.rs`: the `--sitemap` flag on `WebBuildArgs`, URL validation, and the write call in `run_web` (reusing the already-pruned recipe tree).

Design/plan docs: `docs/superpowers/specs/2026-06-06-sitemap-static-site-design.md`, `docs/superpowers/plans/2026-06-06-sitemap-static-site.md`.

## Test Plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass (7 new sitemap unit tests)
- [x] `cook build web /tmp/site --base-path ./seed --sitemap https://recipes.example.com` writes `sitemap.xml`; summary line notes it
- [x] Output is well-formed (`xmllint --noout`) and every `<loc>` maps to a real generated file
- [x] Omitting `--sitemap` produces no sitemap
- [x] Invalid / relative / query-bearing `--sitemap` URLs are rejected with exit code 1
- [x] Two consecutive builds produce byte-identical `sitemap.xml` (deterministic)