### PR TITLE
fix(server): avoid renameat2 SIGSYS on aarch64 Android (Termux)

### DIFF
--- a/src/server/fs_atomic.rs
+++ b/src/server/fs_atomic.rs
@@ -1,0 +1,91 @@
+//! Filesystem helpers that work around platform syscall restrictions.
+//!
+//! On aarch64 the kernel exposes no legacy `rename`/`renameat` syscall, so
+//! libc implements `rename()` via `renameat2`. Android's seccomp filter — and
+//! especially aggressive vendor policies such as Samsung's — blocks
+//! `renameat2`, so any rename raises SIGSYS and the process dies with
+//! "Bad system call". That is *not* a catchable error: SIGSYS terminates the
+//! process before `rename()` returns, so we must avoid the syscall entirely
+//! rather than handle its failure.
+//!
+//! See <https://github.com/cooklang/cookcli/issues/349>.
+
+use camino::Utf8PathBuf;
+use std::io;
+use std::path::Path;
+
+/// Move `from` onto `to`, replacing `to` if it exists.
+///
+/// Uses an atomic `rename` everywhere except Android, where `rename` would hit
+/// the seccomp-blocked `renameat2` syscall. There we fall back to copy + remove,
+/// which is not atomic but uses only permitted syscalls (`openat`/`read`/
+/// `write`/`unlinkat`).
+pub fn rename_replace(from: &Path, to: &Path) -> io::Result<()> {
+    #[cfg(target_os = "android")]
+    {
+        std::fs::copy(from, to)?;
+        std::fs::remove_file(from)?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        std::fs::rename(from, to)
+    }
+}
+
+/// Async wrapper around [`rename_replace`], run on the blocking pool so it does
+/// not stall the async runtime.
+pub async fn rename_replace_async(from: Utf8PathBuf, to: Utf8PathBuf) -> io::Result<()> {
+    tokio::task::spawn_blocking(move || rename_replace(from.as_std_path(), to.as_std_path()))
+        .await
+        .map_err(io::Error::other)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn replaces_destination_and_removes_source() {
+        let dir = TempDir::new().unwrap();
+        let from = dir.path().join("from.tmp");
+        let to = dir.path().join("to.cook");
+        fs::write(&from, b"new contents").unwrap();
+        fs::write(&to, b"old contents").unwrap();
+
+        rename_replace(&from, &to).unwrap();
+
+        assert_eq!(fs::read_to_string(&to).unwrap(), "new contents");
+        assert!(!from.exists(), "source temp file should be gone");
+    }
+
+    #[test]
+    fn creates_destination_when_absent() {
+        let dir = TempDir::new().unwrap();
+        let from = dir.path().join("from.tmp");
+        let to = dir.path().join("to.cook");
+        fs::write(&from, b"contents").unwrap();
+
+        rename_replace(&from, &to).unwrap();
+
+        assert_eq!(fs::read_to_string(&to).unwrap(), "contents");
+        assert!(!from.exists());
+    }
+
+    #[tokio::test]
+    async fn async_wrapper_replaces_destination() {
+        let dir = TempDir::new().unwrap();
+        let from = Utf8PathBuf::from_path_buf(dir.path().join("from.tmp")).unwrap();
+        let to = Utf8PathBuf::from_path_buf(dir.path().join("to.cook")).unwrap();
+        fs::write(&from, b"async contents").unwrap();
+
+        rename_replace_async(from.clone(), to.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(&to).unwrap(), "async contents");
+        assert!(!from.exists());
+    }
+}

--- a/src/server/handlers/recipes.rs
+++ b/src/server/handlers/recipes.rs
@@ -227,7 +227,12 @@ pub async fn recipe_save(
         )
     })?;
 
-    tokio::fs::rename(&temp_path, &file_path)
+    // Replace the original file with the temp file. `rename_replace_async`
+    // uses an atomic rename on capable platforms but copies + removes on
+    // Android, where the aarch64 `rename()` libc wrapper hits the
+    // seccomp-blocked `renameat2` syscall (SIGSYS / "Bad system call").
+    // See https://github.com/cooklang/cookcli/issues/349.
+    crate::server::fs_atomic::rename_replace_async(temp_path.clone(), file_path.clone())
         .await
         .map_err(|e| {
             tracing::error!("Failed to rename temp file to {}: {}", file_path, e);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -48,6 +48,7 @@ use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{error, info};
 
 pub mod builders;
+mod fs_atomic;
 mod handlers;
 mod i18n;
 pub mod language;

--- a/src/server/shopping_list_store.rs
+++ b/src/server/shopping_list_store.rs
@@ -99,8 +99,11 @@ impl ShoppingListStore {
 
         // Rename the old file so it's not picked up again
         let backup = self.legacy_path.with_extension("txt.bak");
-        fs::rename(&self.legacy_path, backup.as_std_path())
-            .context("renaming legacy shopping list to .bak")?;
+        crate::server::fs_atomic::rename_replace(
+            self.legacy_path.as_std_path(),
+            backup.as_std_path(),
+        )
+        .context("renaming legacy shopping list to .bak")?;
 
         tracing::info!("Migration complete. Legacy file renamed to {}", backup);
         Ok(true)
@@ -331,8 +334,9 @@ impl ShoppingListStore {
         // Stage the new content in a sibling temp file, fsync it, and rename
         // into place. Temp path is scoped to base_path so it ends up on the
         // same filesystem — otherwise rename would fall back to copy+delete
-        // and lose atomicity. If any step fails we remove the partial temp
-        // file so it doesn't linger on disk.
+        // and lose atomicity. (On Android `rename_replace` always copies +
+        // removes to dodge the seccomp-blocked `renameat2` syscall.) If any
+        // step fails we remove the partial temp file so it doesn't linger.
         let tmp_path = self.checked_path.with_file_name(".shopping-checked.tmp");
         let write_result = (|| -> Result<()> {
             use std::io::Write as _;
@@ -350,8 +354,11 @@ impl ShoppingListStore {
             let _ = fs::remove_file(&tmp_path);
             return Err(e);
         }
-        if let Err(e) = fs::rename(&tmp_path, &self.checked_path)
-            .context("renaming compacted temp file into place")
+        if let Err(e) = crate::server::fs_atomic::rename_replace(
+            tmp_path.as_std_path(),
+            self.checked_path.as_std_path(),
+        )
+        .context("renaming compacted temp file into place")
         {
             let _ = fs::remove_file(&tmp_path);
             return Err(e);


### PR DESCRIPTION
## Problem

Fixes #349. `cook server` crashes with **"Bad system call"** when saving/editing a recipe on aarch64 Android (reported on Termux on a Samsung S8). Reading recipes works fine — only editing fails.

## Root cause

"Bad system call" is **SIGSYS**, raised by Android's seccomp filter when a process makes a blocked syscall (Samsung devices ship especially strict policies).

The save path (`recipe_save`) writes a temp file and then calls `tokio::fs::rename()`. On **aarch64** the kernel exposes no legacy `rename`/`renameat` syscall, so libc implements `rename()` via **`renameat2`** — which Android/Samsung seccomp blocks → SIGSYS → the server process is killed.

- Reading never renames, so it worked.
- ARM 32-bit isn't affected (it has the permitted legacy `rename`).
- SIGSYS is a *fatal signal*, not an `Err`, so `.map_err()` never runs — the syscall must be **avoided**, not handled.

## Fix

New `server::fs_atomic` module with `rename_replace` / `rename_replace_async`:

- **Non-Android:** atomic `rename` as before (keeps crash-safety on servers/desktops).
- **Android:** `copy` + `remove_file`, which use only permitted syscalls (`openat`/`read`/`write`/`unlinkat`). Non-atomic, but the only option when `renameat2` is forbidden.

All three `fs::rename` sites are routed through it — recipe save, shopping-list compaction, and legacy shopping-list migration — since they share the same root cause and would all crash on the affected device.

## Verification

- `cargo fmt --check` clean
- `cargo clippy` clean on **both** host and `aarch64-linux-android` targets
- `cargo check --target aarch64-linux-android` compiles the Android branch
- `cargo test` — all pass, incl. 3 new unit tests for the helper

### Limitation

The unit tests cover the helper's contract on the host but **cannot reproduce the actual SIGSYS** (that needs aarch64 Android seccomp, unavailable in CI). The fix rests on the root-cause analysis plus confirming the Android branch compiles and avoids `renameat2` by construction. Confirmation from a user on an affected device before release would be ideal.