### PR TITLE
docs(shopping-list): document --pantry, --aisle and related flags

### DIFF
--- a/src/shopping_list.rs
+++ b/src/shopping_list.rs
@@ -95,19 +95,41 @@ pub struct ShoppingListArgs {
     #[arg(long)]
     pretty: bool,
 
-    /// Load aisle conf file
-    #[arg(short, long)]
+    /// Load aisle configuration file
+    ///
+    /// The aisle file groups ingredients into categories (produce, dairy, etc.)
+    /// so the shopping list is organized by store section.
+    ///
+    /// If not specified, the tool looks for `aisle.conf` in `./config/` and then
+    /// in the global config directory (`~/.config/cook/` or the platform
+    /// equivalent).
+    #[arg(short, long, value_hint = clap::ValueHint::FilePath)]
     aisle: Option<Utf8PathBuf>,
 
-    /// Load pantry conf file
-    #[arg(long)]
+    /// Load pantry configuration file
+    ///
+    /// Ingredients you already have on hand are subtracted from the shopping
+    /// list. The pantry file is TOML, with optional quantities and dates.
+    ///
+    /// If not specified, the tool looks for `pantry.conf` in `./config/` and then
+    /// in the global config directory (`~/.config/cook/` or the platform
+    /// equivalent). Use --ignore-pantry to skip pantry subtraction entirely.
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
     pantry: Option<Utf8PathBuf>,
 
     /// Don't expand referenced recipes
+    ///
+    /// By default, recipes referenced from within a recipe (via @./other.cook)
+    /// are expanded and their ingredients included. This flag treats each recipe
+    /// in isolation.
     #[arg(short, long)]
     ignore_references: bool,
 
     /// Don't subtract pantry items from the shopping list
+    ///
+    /// By default, ingredients found in the pantry configuration are subtracted
+    /// from the shopping list. This flag includes every ingredient regardless of
+    /// what's in the pantry, and skips loading the pantry file altogether.
     #[arg(long)]
     ignore_pantry: bool,
 


### PR DESCRIPTION
## Summary

Fleshes out the terse help text for `cook shopping-list`'s `--pantry`, `--aisle`, `--ignore-pantry` and `--ignore-references` flags so they match the detailed, example-rich style of the other options.

## Context

In #333 a user couldn't find/use `--pantry`. The flag itself was added in #340 (shipped in 0.30.0); the reporter was on 0.29.1. But the issue also flagged that the option was poorly documented in `--help`. Each of these flags previously had only a one-line entry — this expands them to explain behaviour and the config auto-discovery (`./config/` then global config dir).

No behavioural change; documentation only.

## Verification

- `cargo build`, `cargo fmt`, `cargo clippy` all clean
- `cook shopping-list --help` renders the expanded entries

Refs #333