### PR TITLE
feat: make shopping list and pantry nav links configurable via settings

### DIFF
--- a/docs/superpowers/plans/2026-06-08-feature-flags-nav.md
+++ b/docs/superpowers/plans/2026-06-08-feature-flags-nav.md
@@ -1,0 +1,1329 @@
+# Feature Flags: Configurable Nav Bar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users enable/disable Shopping List and Pantry nav links from the Preferences page; both features are shown by default and the setting persists via cookies refreshed on every request.
+
+**Architecture:** A `FeatureFlags` struct lives in `src/server/language.rs` alongside the existing language cookie logic. An Axum middleware reads feature flag cookies, injects `FeatureFlags` as a request extension, and refreshes the cookie expiry on every response. Every template struct gains a `features: FeatureFlags` field; `base.html` renders nav pills conditionally; `preferences.html` shows toggle buttons.
+
+**Tech Stack:** Rust/Axum, Askama templates, Tailwind CSS, Fluent (FTL) i18n, Playwright (E2E tests)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/server/language.rs` | Add `FeatureFlags`, `parse_feature_flags`, `features_middleware` |
+| `src/server/mod.rs` | Register `features_middleware` with `from_fn_with_state` |
+| `src/server/templates.rs` | Add `features: FeatureFlags` to all 9 template structs |
+| `src/server/builders.rs` | Add `features` to `RecipesBuildInput` and `RecipeBuildInput`; thread through |
+| `src/server/ui.rs` | Extract `Extension(features)` in every handler; update `error_page` |
+| `src/build/renderer.rs` | Pass `FeatureFlags::default()` to builder inputs (static mode) |
+| `templates/base.html` | Conditional nav pills (desktop + mobile dropdown); dark mode CSS |
+| `templates/preferences.html` | Features section card + `toggleFeature` JS |
+| `locales/en-US/preferences.ftl` | Add `pref-features`, `pref-features-desc` |
+| `locales/de-DE/preferences.ftl` | Same |
+| `locales/nl-NL/preferences.ftl` | Same |
+| `locales/fr-FR/preferences.ftl` | Same |
+| `locales/es-ES/preferences.ftl` | Same |
+| `locales/eu-ES/preferences.ftl` | Same |
+| `locales/sv-SE/preferences.ftl` | Same |
+| `tests/e2e/navigation.spec.ts` | Tests for feature-flag nav visibility |
+| `tests/e2e/preferences.spec.ts` | Tests for feature toggle in preferences UI |
+
+---
+
+## Task 1: `FeatureFlags` struct and cookie parsing
+
+**Files:**
+- Modify: `src/server/language.rs`
+
+- [ ] **Step 1.1 — Write the failing unit tests**
+
+Add at the bottom of `src/server/language.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cookie_headers(cookies: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::COOKIE, cookies.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn test_feature_flags_default_true_when_no_cookies() {
+        let flags = parse_feature_flags(&HeaderMap::new());
+        assert!(flags.show_shopping_list);
+        assert!(flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_disabled_by_zero() {
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=0; show_pantry=0",
+        ));
+        assert!(!flags.show_shopping_list);
+        assert!(!flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_enabled_by_one() {
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=1; show_pantry=1",
+        ));
+        assert!(flags.show_shopping_list);
+        assert!(flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_partial_override() {
+        let flags =
+            parse_feature_flags(&make_cookie_headers("show_shopping_list=0"));
+        assert!(!flags.show_shopping_list);
+        assert!(flags.show_pantry); // absent → default true
+    }
+
+    #[test]
+    fn test_feature_flags_unknown_value_treated_as_enabled() {
+        // Anything that isn't "0" is truthy
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=yes",
+        ));
+        assert!(flags.show_shopping_list);
+    }
+}
+```
+
+- [ ] **Step 1.2 — Run tests to confirm they fail**
+
+```bash
+cd /Users/romain/Projects/cooklang/cookcli
+cargo test test_feature_flags 2>&1 | head -30
+```
+
+Expected: compile errors — `parse_feature_flags` and `FeatureFlags` are not defined yet.
+
+- [ ] **Step 1.3 — Implement `FeatureFlags` and `parse_feature_flags`**
+
+Add the following to `src/server/language.rs` after the `SUPPORTED_LANGUAGES` constant (around line 20):
+
+```rust
+/// Per-request feature visibility flags, read from cookies.
+#[derive(Clone, Debug)]
+pub struct FeatureFlags {
+    pub show_shopping_list: bool,
+    pub show_pantry: bool,
+}
+
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        Self {
+            show_shopping_list: true,
+            show_pantry: true,
+        }
+    }
+}
+
+/// Parse feature flag cookies from request headers.
+/// Absent cookie → feature enabled (default true).
+/// Cookie value "0" → disabled. Any other value → enabled.
+pub fn parse_feature_flags(headers: &HeaderMap) -> FeatureFlags {
+    let mut flags = FeatureFlags::default();
+
+    if let Some(cookie_header) = headers.get(header::COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            for cookie in cookie_str.split(';') {
+                let parts: Vec<&str> = cookie.trim().splitn(2, '=').collect();
+                if parts.len() == 2 {
+                    match parts[0] {
+                        "show_shopping_list" => {
+                            flags.show_shopping_list = parts[1] != "0"
+                        }
+                        "show_pantry" => flags.show_pantry = parts[1] != "0",
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    flags
+}
+```
+
+- [ ] **Step 1.4 — Run tests to confirm they pass**
+
+```bash
+cargo test test_feature_flags 2>&1
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 1.5 — Commit**
+
+```bash
+git add src/server/language.rs
+git commit -m "feat: add FeatureFlags struct and cookie parsing for nav feature toggles"
+```
+
+---
+
+## Task 2: Features middleware
+
+**Files:**
+- Modify: `src/server/language.rs`
+- Modify: `src/server/mod.rs`
+
+- [ ] **Step 2.1 — Add `State` to imports in `language.rs`**
+
+In `src/server/language.rs`, change the existing `use axum::{...}` block to include `State`:
+
+```rust
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderMap},
+    middleware::Next,
+    response::Response,
+};
+```
+
+- [ ] **Step 2.2 — Implement `features_middleware` in `language.rs`**
+
+Add after the `language_middleware` function:
+
+```rust
+/// Middleware that reads feature flag cookies, injects them as a request
+/// extension, and refreshes the cookie expiry on every response.
+/// Takes the URL prefix as state so Set-Cookie headers use the correct path.
+pub async fn features_middleware(
+    State(url_prefix): State<String>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let features = parse_feature_flags(req.headers());
+    req.extensions_mut().insert(features.clone());
+    let mut response = next.run(req).await;
+
+    let max_age = 365 * 24 * 60 * 60_u32;
+    let cookie_path = if url_prefix.is_empty() {
+        "/".to_string()
+    } else {
+        url_prefix.clone()
+    };
+
+    for (name, val) in [
+        (
+            "show_shopping_list",
+            if features.show_shopping_list { "1" } else { "0" },
+        ),
+        ("show_pantry", if features.show_pantry { "1" } else { "0" }),
+    ] {
+        let cookie = format!(
+            "{name}={val}; path={cookie_path}; max-age={max_age}; SameSite=Lax"
+        );
+        if let Ok(header_val) = cookie.parse() {
+            response.headers_mut().append(header::SET_COOKIE, header_val);
+        }
+    }
+
+    response
+}
+```
+
+- [ ] **Step 2.3 — Register the middleware in `mod.rs`**
+
+In `src/server/mod.rs`, in the `run` function, extract `url_prefix` before `with_state` consumes `state`, then register the middleware. Find the block starting with `#[cfg(feature = "sync")] let state_for_shutdown = state.clone();` and add the prefix capture right before it:
+
+```rust
+    // Capture url_prefix before state is consumed by with_state.
+    let url_prefix_for_features = state.url_prefix.clone();
+
+    #[cfg(feature = "sync")]
+    let state_for_shutdown = state.clone();
+
+    let app = app
+        .with_state(state)
+        .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
+        .layer(axum::middleware::from_fn_with_state(
+            url_prefix_for_features,
+            language::features_middleware,
+        ))
+        .layer(axum::middleware::from_fn(language::language_middleware))
+        .layer(
+            CorsLayer::new()
+                .allow_origin("*".parse::<HeaderValue>().unwrap())
+                .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]),
+        );
+```
+
+- [ ] **Step 2.4 — Build to confirm it compiles**
+
+```bash
+cargo build -p cookcli 2>&1 | grep -E "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 2.5 — Commit**
+
+```bash
+git add src/server/language.rs src/server/mod.rs
+git commit -m "feat: add features_middleware that injects FeatureFlags and refreshes cookies"
+```
+
+---
+
+## Task 3: Add `FeatureFlags` to template structs, builders, and handlers
+
+This task must be done in one step because Askama validates template fields at compile time. All structs must have `features` before templates can reference it.
+
+**Files:**
+- Modify: `src/server/templates.rs`
+- Modify: `src/server/builders.rs`
+- Modify: `src/server/ui.rs`
+- Modify: `src/build/renderer.rs`
+
+- [ ] **Step 3.1 — Add import and `features` field to all template structs in `templates.rs`**
+
+At the top of `src/server/templates.rs`, add the import after the existing imports:
+
+```rust
+use crate::server::language::FeatureFlags;
+```
+
+Then add `pub features: FeatureFlags,` to each template struct. The complete list of structs to update and their new fields (add after the last existing field in each):
+
+```rust
+// ErrorTemplate
+pub struct ErrorTemplate {
+    pub active: String,
+    pub error_message: String,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// RecipesTemplate
+pub struct RecipesTemplate {
+    pub active: String,
+    pub current_name: String,
+    pub breadcrumbs: Vec<Breadcrumb>,
+    pub items: Vec<RecipeItem>,
+    pub todays_menu: Option<TodaysMenu>,
+    pub new_recipe_url: String,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// RecipeTemplate
+pub struct RecipeTemplate {
+    pub active: String,
+    pub recipe: RecipeData,
+    pub recipe_path: String,
+    pub breadcrumbs: Vec<String>,
+    pub scale: f64,
+    pub tags: Vec<String>,
+    pub ingredients: Vec<IngredientData>,
+    pub cookware: Vec<CookwareData>,
+    pub sections: Vec<RecipeSection>,
+    pub image_path: Option<String>,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// MenuTemplate
+pub struct MenuTemplate {
+    pub active: String,
+    pub name: String,
+    pub recipe_path: String,
+    pub breadcrumbs: Vec<String>,
+    pub scale: f64,
+    pub metadata: Option<RecipeMetadata>,
+    pub sections: Vec<MenuSection>,
+    pub image_path: Option<String>,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// ShoppingListTemplate
+pub struct ShoppingListTemplate {
+    pub active: String,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// PreferencesTemplate
+pub struct PreferencesTemplate {
+    pub active: String,
+    pub aisle_path: String,
+    pub pantry_path: String,
+    pub base_path: String,
+    pub version: String,
+    pub tr: Tr,
+    pub sync_enabled: bool,
+    pub sync_logged_in: bool,
+    pub sync_email: Option<String>,
+    pub sync_syncing: bool,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// PantryTemplate
+pub struct PantryTemplate {
+    pub active: String,
+    pub configured: bool,
+    pub sections: Vec<PantrySection>,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// EditTemplate
+pub struct EditTemplate {
+    pub active: String,
+    pub recipe_name: String,
+    pub recipe_path: String,
+    pub content: String,
+    pub base_path: String,
+    pub tr: Tr,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+
+// NewTemplate
+pub struct NewTemplate {
+    pub active: String,
+    pub tr: Tr,
+    pub error: Option<String>,
+    pub filename: Option<String>,
+    pub prefix: String,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+```
+
+- [ ] **Step 3.2 — Add `features` to builder input structs in `builders.rs`**
+
+In `src/server/builders.rs`, add to imports at top:
+
+```rust
+use crate::server::language::FeatureFlags;
+```
+
+Update `RecipesBuildInput`:
+
+```rust
+pub struct RecipesBuildInput<'a> {
+    pub base_path: &'a Utf8Path,
+    pub url_prefix: &'a str,
+    pub sub_path: Option<&'a str>,
+    pub lang: LanguageIdentifier,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+```
+
+Update `RecipeBuildInput`:
+
+```rust
+pub struct RecipeBuildInput<'a> {
+    pub base_path: &'a Utf8Path,
+    pub url_prefix: &'a str,
+    pub recipe_path: &'a str,
+    pub aisle_path: Option<&'a Utf8PathBuf>,
+    pub scale: f64,
+    pub lang: LanguageIdentifier,
+    pub static_mode: bool,
+    pub features: FeatureFlags,        // ADD
+}
+```
+
+In `build_recipes_template`, destructure the new field and pass it to the template:
+
+```rust
+pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTemplate> {
+    let RecipesBuildInput {
+        base_path,
+        url_prefix,
+        sub_path,
+        lang,
+        static_mode,
+        features,          // ADD
+    } = input;
+    // ... existing body unchanged ...
+    Ok(RecipesTemplate {
+        active: "recipes".to_string(),
+        current_name,
+        breadcrumbs,
+        items,
+        todays_menu,
+        new_recipe_url,
+        tr: Tr::new(lang),
+        prefix: url_prefix.to_string(),
+        static_mode,
+        features,          // ADD
+    })
+}
+```
+
+In `build_recipe_template`, destructure and thread through. In the `RecipeBuildInput` destructuring block:
+
+```rust
+    let RecipeBuildInput {
+        base_path,
+        url_prefix,
+        recipe_path,
+        aisle_path,
+        scale,
+        lang,
+        static_mode,
+        features,          // ADD
+    } = input;
+```
+
+Pass to `RecipeTemplate` at the bottom of `build_recipe_template`:
+
+```rust
+    let template = RecipeTemplate {
+        active: "recipes".to_string(),
+        recipe: RecipeData { name: recipe_name, metadata },
+        recipe_path: recipe_path.to_string(),
+        breadcrumbs,
+        scale,
+        tags,
+        ingredients,
+        cookware,
+        sections,
+        image_path,
+        tr: Tr::new(lang),
+        prefix: url_prefix.to_string(),
+        static_mode,
+        features,              // ADD
+    };
+```
+
+Pass to `build_menu_template_inner` (which builds `MenuTemplate`). Update the call in `build_recipe_template`:
+
+```rust
+        let template = build_menu_template_inner(
+            recipe_path.to_string(),
+            scale,
+            entry,
+            base_path,
+            url_prefix,
+            lang,
+            static_mode,
+            features,          // ADD
+        )?;
+```
+
+Update `build_menu_template_inner` signature and constructor:
+
+```rust
+fn build_menu_template_inner(
+    path: String,
+    scale: f64,
+    entry: cooklang_find::RecipeEntry,
+    base_path: &Utf8Path,
+    url_prefix: &str,
+    lang: LanguageIdentifier,
+    static_mode: bool,
+    features: FeatureFlags,    // ADD
+) -> Result<MenuTemplate> {
+    // ... existing body unchanged ...
+    Ok(MenuTemplate {
+        active: "recipes".to_string(),
+        name: menu_name,
+        recipe_path: path,
+        breadcrumbs,
+        scale,
+        metadata,
+        sections,
+        image_path,
+        tr: Tr::new(lang),
+        prefix: url_prefix.to_string(),
+        static_mode,
+        features,              // ADD
+    })
+}
+```
+
+- [ ] **Step 3.3 — Update `renderer.rs` to pass `FeatureFlags::default()`**
+
+In `src/build/renderer.rs`, add import at top:
+
+```rust
+use crate::server::language::FeatureFlags;
+```
+
+In `render_index`, update the `RecipesBuildInput`:
+
+```rust
+    let template = build_recipes_template(RecipesBuildInput {
+        base_path: source,
+        url_prefix: &prefix,
+        sub_path: None,
+        lang: lang.clone(),
+        static_mode: true,
+        features: FeatureFlags::default(),    // ADD
+    })?;
+```
+
+In `render_directory`, same change:
+
+```rust
+    let template = build_recipes_template(RecipesBuildInput {
+        base_path: source,
+        url_prefix: &prefix,
+        sub_path: Some(sub_path),
+        lang: lang.clone(),
+        static_mode: true,
+        features: FeatureFlags::default(),    // ADD
+    })?;
+```
+
+In `render_recipe`, update `RecipeBuildInput`:
+
+```rust
+    let kind = build_recipe_template(RecipeBuildInput {
+        base_path: source,
+        url_prefix: &prefix,
+        recipe_path: trimmed,
+        aisle_path,
+        scale: 1.0,
+        lang: lang.clone(),
+        static_mode: true,
+        features: FeatureFlags::default(),    // ADD
+    })?;
+```
+
+- [ ] **Step 3.4 — Update all handlers in `ui.rs`**
+
+Add import at the top of `src/server/ui.rs`:
+
+```rust
+use crate::server::language::FeatureFlags;
+```
+
+Update `error_page` helper to accept and pass features:
+
+```rust
+fn error_page(
+    lang: LanguageIdentifier,
+    prefix: &str,
+    msg: impl std::fmt::Display,
+    features: FeatureFlags,
+) -> axum::response::Response {
+    let template = ErrorTemplate {
+        active: String::new(),
+        error_message: msg.to_string(),
+        tr: Tr::new(lang),
+        prefix: prefix.to_string(),
+        static_mode: false,
+        features,
+    };
+    template.into_response()
+}
+```
+
+Update `recipes_page`:
+
+```rust
+async fn recipes_page(
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> axum::response::Response {
+    recipes_handler(state, None, lang, features).await
+}
+```
+
+Update `recipes_directory`:
+
+```rust
+async fn recipes_directory(
+    Path(path): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> axum::response::Response {
+    recipes_handler(state, Some(path), lang, features).await
+}
+```
+
+Update `recipes_handler` to accept and thread features:
+
+```rust
+async fn recipes_handler(
+    state: Arc<AppState>,
+    path: Option<String>,
+    lang: LanguageIdentifier,
+    features: FeatureFlags,
+) -> axum::response::Response {
+    let input = crate::server::builders::RecipesBuildInput {
+        base_path: &state.base_path,
+        url_prefix: &state.url_prefix,
+        sub_path: path.as_deref(),
+        lang: lang.clone(),
+        static_mode: false,
+        features: features.clone(),
+    };
+    match crate::server::builders::build_recipes_template(input) {
+        Ok(template) => template.into_response(),
+        Err(e) => {
+            tracing::error!("Failed to build recipes template: {:?}", e);
+            error_page(lang, &state.url_prefix, &e, features)
+        }
+    }
+}
+```
+
+Update `recipe_page`:
+
+```rust
+async fn recipe_page(
+    Path(path): Path<String>,
+    Query(query): Query<RecipeQuery>,
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> axum::response::Response {
+    let scale = query.scale.unwrap_or(1.0);
+
+    let input = crate::server::builders::RecipeBuildInput {
+        base_path: &state.base_path,
+        url_prefix: &state.url_prefix,
+        recipe_path: &path,
+        aisle_path: state.aisle_path.as_ref(),
+        scale,
+        lang: lang.clone(),
+        static_mode: false,
+        features: features.clone(),
+    };
+
+    match crate::server::builders::build_recipe_template(input) {
+        Ok(crate::server::builders::RecipeBuildOutput::Recipe(template)) => {
+            template.into_response()
+        }
+        Ok(crate::server::builders::RecipeBuildOutput::Menu(template)) => template.into_response(),
+        Err(e) => {
+            tracing::error!("Failed to build recipe template: {:?}", e);
+            error_page(lang, &state.url_prefix, &e, features)
+        }
+    }
+}
+```
+
+Update `edit_page`:
+
+```rust
+async fn edit_page(
+    Path(path): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> axum::response::Response {
+    // ... existing validation/reading logic unchanged ...
+    let template = crate::server::templates::EditTemplate {
+        active: "recipes".to_string(),
+        recipe_name,
+        recipe_path: path,
+        content,
+        base_path: state.base_path.to_string(),
+        tr: crate::server::templates::Tr::new(lang),
+        prefix: state.url_prefix.clone(),
+        static_mode: false,
+        features,
+    };
+    template.into_response()
+}
+```
+
+(Keep all the existing path validation and file reading logic unchanged; just add `Extension(features): Extension<FeatureFlags>` to the signature and `features,` to the template constructor.)
+
+Update `new_page`:
+
+```rust
+async fn new_page(
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+    Query(query): Query<NewPageQuery>,
+) -> impl askama_axum::IntoResponse {
+    crate::server::templates::NewTemplate {
+        active: "recipes".to_string(),
+        tr: Tr::new(lang),
+        error: query.error,
+        filename: query.filename,
+        prefix: state.url_prefix.clone(),
+        static_mode: false,
+        features,
+    }
+}
+```
+
+Update `shopping_list_page`:
+
+```rust
+async fn shopping_list_page(
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> impl askama_axum::IntoResponse {
+    ShoppingListTemplate {
+        active: "shopping".to_string(),
+        tr: Tr::new(lang),
+        prefix: state.url_prefix.clone(),
+        static_mode: false,
+        features,
+    }
+}
+```
+
+Update `pantry_page`:
+
+```rust
+async fn pantry_page(
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> Result<impl askama_axum::IntoResponse, StatusCode> {
+    // ... existing pantry loading logic unchanged ...
+    Ok(PantryTemplate {
+        active: "pantry".to_string(),
+        configured: pantry_path.is_some(),
+        sections,
+        tr: Tr::new(lang),
+        prefix: state.url_prefix.clone(),
+        static_mode: false,
+        features,
+    })
+}
+```
+
+Update `preferences_page`:
+
+```rust
+async fn preferences_page(
+    State(state): State<Arc<AppState>>,
+    Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
+) -> impl askama_axum::IntoResponse {
+    #[cfg(feature = "sync")]
+    let (sync_logged_in, sync_email, sync_syncing) = state.sync_status().await;
+    #[cfg(not(feature = "sync"))]
+    let (sync_logged_in, sync_email, sync_syncing) = (false, None, false);
+
+    PreferencesTemplate {
+        active: "preferences".to_string(),
+        aisle_path: state
+            .aisle_path
+            .as_ref()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "Not configured".to_string()),
+        pantry_path: state
+            .pantry_path
+            .as_ref()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "Not configured".to_string()),
+        base_path: state.base_path.to_string(),
+        version: format!("{} - in food we trust", env!("CARGO_PKG_VERSION")),
+        tr: Tr::new(lang),
+        sync_enabled: cfg!(feature = "sync"),
+        sync_logged_in,
+        sync_email,
+        sync_syncing,
+        prefix: state.url_prefix.clone(),
+        static_mode: false,
+        features,
+    }
+}
+```
+
+- [ ] **Step 3.5 — Build to confirm it compiles cleanly**
+
+```bash
+cargo build -p cookcli 2>&1 | grep -E "^error"
+```
+
+Expected: no errors. If Askama reports a missing `features` field for a template, check that all 9 structs were updated.
+
+- [ ] **Step 3.6 — Commit**
+
+```bash
+git add src/server/templates.rs src/server/builders.rs src/server/ui.rs src/build/renderer.rs
+git commit -m "feat: thread FeatureFlags through all template structs, builders, and handlers"
+```
+
+---
+
+## Task 4: Conditional nav links in `base.html`
+
+**Files:**
+- Modify: `templates/base.html`
+
+- [ ] **Step 4.1 — Add dark mode CSS for `.nav-pill`**
+
+In `templates/base.html`, inside the existing `<style>` block, after the existing `.dark .hover\:text-purple-700:hover` rule (around line 241), add:
+
+```css
+        /* Nav pill dark mode */
+        .dark .nav-pill {
+            color: #9ca3af;
+        }
+
+        .dark .nav-pill:hover {
+            background: #374151;
+            color: #fb923c;
+        }
+
+        .dark .nav-pill.active {
+            background: linear-gradient(135deg, #ff6b35, #f97316);
+            color: white;
+        }
+```
+
+- [ ] **Step 4.2 — Add desktop nav pills inside the nav bar**
+
+In `templates/base.html`, find the `order-3` div (around line 773):
+
+```html
+<div class="order-3 w-full md:w-auto flex items-center gap-1 lg:gap-2">
+```
+
+Insert the following block immediately after the opening `<div class="order-3 ...">` tag, before the existing preferences button:
+
+```html
+                        {% if features.show_shopping_list || features.show_pantry %}
+                        <div class="hidden md:flex items-center mr-2 lg:mr-4">
+                            <a href="{{ prefix }}{% if static_mode %}/index.html{% endif %}"
+                               class="nav-pill {% if active == "recipes" %}active{% endif %}">
+                                {{ tr.t("nav-recipes") }}
+                            </a>
+                            {% if features.show_shopping_list && !static_mode %}
+                            <a href="{{ prefix }}/shopping-list"
+                               class="nav-pill {% if active == "shopping" %}active{% endif %}">
+                                {{ tr.t("nav-shopping-list") }}
+                            </a>
+                            {% endif %}
+                            {% if features.show_pantry && !static_mode %}
+                            <a href="{{ prefix }}/pantry"
+                               class="nav-pill {% if active == "pantry" %}active{% endif %}">
+                                {{ tr.t("nav-pantry") }}
+                            </a>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+```
+
+- [ ] **Step 4.3 — Add nav links to the mobile overflow dropdown**
+
+In `templates/base.html`, find the `more-dropdown` div (around line 800). Inside it, just before the existing `{% if !static_mode %}` preferences link, insert:
+
+```html
+                                {% if features.show_shopping_list || features.show_pantry %}
+                                <a href="{{ prefix }}{% if static_mode %}/index.html{% endif %}" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "recipes" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🍳</span> <span>{{ tr.t("nav-recipes") }}</span>
+                                </a>
+                                {% if features.show_shopping_list && !static_mode %}
+                                <a href="{{ prefix }}/shopping-list" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "shopping" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🛒</span> <span>{{ tr.t("nav-shopping-list") }}</span>
+                                </a>
+                                {% endif %}
+                                {% if features.show_pantry && !static_mode %}
+                                <a href="{{ prefix }}/pantry" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "pantry" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🥫</span> <span>{{ tr.t("nav-pantry") }}</span>
+                                </a>
+                                {% endif %}
+                                <div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
+                                {% endif %}
+```
+
+- [ ] **Step 4.4 — Build and verify no template errors**
+
+```bash
+cargo build -p cookcli 2>&1 | grep -E "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 4.5 — Commit**
+
+```bash
+git add templates/base.html
+git commit -m "feat: add conditional nav pills for shopping list and pantry in base.html"
+```
+
+---
+
+## Task 5: Features section in `preferences.html`
+
+**Files:**
+- Modify: `templates/preferences.html`
+
+- [ ] **Step 5.1 — Add the Features section card**
+
+In `templates/preferences.html`, find the Language Selector section (the `bg-gradient-to-r from-purple-50 to-pink-50` div). Add the Features section immediately after it, before the CookCloud sync section:
+
+```html
+        <!-- Features -->
+        {% if !static_mode %}
+        <div class="bg-gradient-to-r from-blue-50 to-indigo-50 p-6 rounded-2xl border-2 border-blue-200">
+            <h2 class="text-lg font-semibold mb-2 text-blue-900">{{ tr.t("pref-features") }}</h2>
+            <p class="text-sm text-blue-700 mb-4">{{ tr.t("pref-features-desc") }}</p>
+            <div class="flex flex-wrap gap-3">
+                <button onclick="toggleFeature('show_shopping_list', {{ features.show_shopping_list }})"
+                        class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_shopping_list %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+                    🛒 {{ tr.t("nav-shopping-list") }}
+                </button>
+                <button onclick="toggleFeature('show_pantry', {{ features.show_pantry }})"
+                        class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_pantry %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+                    🥫 {{ tr.t("nav-pantry") }}
+                </button>
+            </div>
+        </div>
+        {% endif %}
+```
+
+- [ ] **Step 5.2 — Add `toggleFeature` JS function**
+
+In `templates/preferences.html`, inside the `{% block scripts %}<script>` block, add before the closing `</script>` tag (before the `{% if sync_enabled %}` block):
+
+```js
+    function toggleFeature(name, current) {
+        const val = current ? '0' : '1';
+        const maxAge = 365 * 24 * 60 * 60;
+        document.cookie = `${name}=${val}; path={{ prefix }}/; max-age=${maxAge}; SameSite=Lax`;
+        window.location.reload();
+    }
+```
+
+- [ ] **Step 5.3 — Build to confirm no errors**
+
+```bash
+cargo build -p cookcli 2>&1 | grep -E "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5.4 — Commit**
+
+```bash
+git add templates/preferences.html
+git commit -m "feat: add Features section to preferences page with shopping list and pantry toggles"
+```
+
+---
+
+## Task 6: Add translations to all 7 locale files
+
+**Files:**
+- Modify: `locales/en-US/preferences.ftl`
+- Modify: `locales/de-DE/preferences.ftl`
+- Modify: `locales/nl-NL/preferences.ftl`
+- Modify: `locales/fr-FR/preferences.ftl`
+- Modify: `locales/es-ES/preferences.ftl`
+- Modify: `locales/eu-ES/preferences.ftl`
+- Modify: `locales/sv-SE/preferences.ftl`
+
+- [ ] **Step 6.1 — Add keys to `locales/en-US/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Features
+pref-features-desc = Choose which features appear in the navigation bar.
+```
+
+- [ ] **Step 6.2 — Add keys to `locales/de-DE/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Funktionen
+pref-features-desc = Wähle, welche Funktionen in der Navigationsleiste angezeigt werden.
+```
+
+- [ ] **Step 6.3 — Add keys to `locales/nl-NL/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Functies
+pref-features-desc = Kies welke functies in de navigatiebalk worden weergegeven.
+```
+
+- [ ] **Step 6.4 — Add keys to `locales/fr-FR/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Fonctionnalités
+pref-features-desc = Choisissez les fonctionnalités à afficher dans la barre de navigation.
+```
+
+- [ ] **Step 6.5 — Add keys to `locales/es-ES/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Funcionalidades
+pref-features-desc = Elige qué funciones se muestran en la barra de navegación.
+```
+
+- [ ] **Step 6.6 — Add keys to `locales/eu-ES/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Eginbideak
+pref-features-desc = Aukeratu nabigazio-barran zer eginbide erakutsi nahi duzun.
+```
+
+- [ ] **Step 6.7 — Add keys to `locales/sv-SE/preferences.ftl`**
+
+Append to end of file:
+
+```
+# Features
+pref-features = Funktioner
+pref-features-desc = Välj vilka funktioner som visas i navigeringsfältet.
+```
+
+- [ ] **Step 6.8 — Build to confirm Fluent keys are valid**
+
+```bash
+cargo build -p cookcli 2>&1 | grep -E "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 6.9 — Commit**
+
+```bash
+git add locales/
+git commit -m "feat: add pref-features translation keys to all 7 locales"
+```
+
+---
+
+## Task 7: Manual smoke test before E2E tests
+
+- [ ] **Step 7.1 — Build CSS**
+
+```bash
+cd /Users/romain/Projects/cooklang/cookcli && npm run build-css 2>&1 | tail -5
+```
+
+Expected: completes without error.
+
+- [ ] **Step 7.2 — Start the dev server**
+
+In a separate terminal (or background):
+
+```bash
+cargo run -- server ./seed 2>&1 &
+sleep 3
+```
+
+- [ ] **Step 7.3 — Verify default nav shows Shopping List and Pantry**
+
+Open `http://localhost:9080` in a browser. Expected: nav bar shows **Recipes**, **Shopping List**, **Pantry** pills.
+
+- [ ] **Step 7.4 — Toggle off Shopping List**
+
+Go to `http://localhost:9080/preferences`. Expected: Features section visible with two active (orange) buttons. Click **Shopping List** button. Page reloads. Expected: Shopping List button becomes inactive (white), nav no longer shows Shopping List pill.
+
+- [ ] **Step 7.5 — Toggle off Pantry**
+
+Click **Pantry** button. Page reloads. Expected: both buttons inactive, nav shows no feature pills (not even Recipes).
+
+- [ ] **Step 7.6 — Toggle Shopping List back on**
+
+Click **Shopping List** button. Page reloads. Expected: nav shows **Recipes** and **Shopping List** pills; Pantry still absent.
+
+- [ ] **Step 7.7 — Verify cookie refresh**
+
+Open browser DevTools → Application → Cookies. Expected: `show_shopping_list` and `show_pantry` cookies present with 1-year expiry.
+
+---
+
+## Task 8: E2E tests
+
+**Files:**
+- Modify: `tests/e2e/navigation.spec.ts`
+- Modify: `tests/e2e/preferences.spec.ts`
+
+- [ ] **Step 8.1 — Add feature flag nav tests to `navigation.spec.ts`**
+
+Add the following test block at the end of `tests/e2e/navigation.spec.ts`:
+
+```typescript
+test.describe('Feature flag nav visibility', () => {
+  test.beforeEach(async ({ context }) => {
+    // Reset both feature flags to default (enabled) before each test
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '1', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '1', url: 'http://localhost:9080' },
+    ]);
+  });
+
+  test('shows Recipes, Shopping List, and Pantry nav links by default', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).toBeVisible();
+  });
+
+  test('hides Shopping List nav link when cookie is 0', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).not.toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).toBeVisible();
+  });
+
+  test('hides Pantry nav link when cookie is 0', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_pantry', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).not.toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+  });
+
+  test('shows no nav pills when both features are disabled', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill')).toHaveCount(0);
+  });
+
+  test('nav pill is active on its corresponding page', async ({ page }) => {
+    await page.goto('/shopping-list');
+    await page.waitForLoadState('domcontentloaded');
+
+    const shoppingPill = page.locator('nav a.nav-pill.active');
+    await expect(shoppingPill).toBeVisible();
+    await expect(shoppingPill).toContainText(/Shopping/i);
+  });
+});
+```
+
+- [ ] **Step 8.2 — Add feature toggle test to `preferences.spec.ts`**
+
+Add the following test block at the end of `tests/e2e/preferences.spec.ts`:
+
+```typescript
+test.describe('Feature toggles in preferences', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '1', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '1', url: 'http://localhost:9080' },
+    ]);
+  });
+
+  test('displays Features section with two active buttons', async ({ page }) => {
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    const shoppingBtn = page.getByRole('button', { name: /Shopping/i });
+    const pantryBtn = page.getByRole('button', { name: /Pantry/i });
+
+    await expect(shoppingBtn).toBeVisible();
+    await expect(pantryBtn).toBeVisible();
+
+    // Both enabled → should have the active (orange gradient) classes
+    await expect(shoppingBtn).toHaveClass(/from-orange-500/);
+    await expect(pantryBtn).toHaveClass(/from-orange-500/);
+  });
+
+  test('toggling Shopping List off removes it from nav', async ({ page }) => {
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /Shopping/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Button is now inactive
+    const shoppingBtn = page.getByRole('button', { name: /Shopping/i });
+    await expect(shoppingBtn).not.toHaveClass(/from-orange-500/);
+
+    // Nav no longer shows Shopping List
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).not.toBeVisible();
+  });
+
+  test('toggling a feature back on restores the nav link', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    // Shopping is currently off — click to enable
+    await page.getByRole('button', { name: /Shopping/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 8.3 — Run the new E2E tests**
+
+```bash
+cd /Users/romain/Projects/cooklang/cookcli
+npx playwright test tests/e2e/navigation.spec.ts tests/e2e/preferences.spec.ts --reporter=line 2>&1 | tail -30
+```
+
+Expected: all new tests pass (existing tests continue to pass).
+
+- [ ] **Step 8.4 — Run full test suite**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: all Rust tests pass.
+
+- [ ] **Step 8.5 — Commit**
+
+```bash
+git add tests/e2e/navigation.spec.ts tests/e2e/preferences.spec.ts
+git commit -m "test: add E2E tests for feature flag nav visibility and preference toggles"
+```

--- a/docs/superpowers/specs/2026-06-08-feature-flags-nav-design.md
+++ b/docs/superpowers/specs/2026-06-08-feature-flags-nav-design.md
@@ -1,0 +1,170 @@
+# Feature Flags: Configurable Nav Bar
+
+**Date:** 2026-06-08
+
+## Problem
+
+Shopping List and Pantry were removed from the nav bar in a previous commit. Users who want those features back have no way to re-enable them. Recipes is always the default/mandatory page.
+
+## Goal
+
+Let users choose which features appear in the nav bar via the Preferences page. Shopping List and Pantry are shown by default (opt-out). Recipes is always the home page and cannot be hidden. If only Recipes is enabled, no nav links are shown at all (the bar still shows search, preferences, and theme toggle).
+
+## Approach: Cookie-based, server-side rendering
+
+Feature flags are stored as cookies, read in middleware, and injected as an Axum extension — exactly mirroring how the `lang` cookie and `LanguageIdentifier` extension work today. Askama templates render conditionally; no JS is needed for the nav itself.
+
+---
+
+## Data & Storage
+
+### `FeatureFlags` struct
+
+New struct in `src/server/language.rs` (alongside the existing language helpers):
+
+```rust
+#[derive(Clone, Debug)]
+pub struct FeatureFlags {
+    pub show_shopping_list: bool,
+    pub show_pantry: bool,
+}
+
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        Self { show_shopping_list: true, show_pantry: true }
+    }
+}
+```
+
+### Cookies
+
+| Cookie name          | Values  | Absent means |
+|----------------------|---------|--------------|
+| `show_shopping_list` | `1`/`0` | enabled (true) |
+| `show_pantry`        | `1`/`0` | enabled (true) |
+
+Set with `path=<prefix>/; max-age=31536000; SameSite=Lax` (1-year expiry).
+
+The middleware refreshes both cookies on every response, resetting their expiry to 1 year from the current request. This means preferences persist indefinitely as long as the user visits occasionally — they only expire if the user hasn't visited for a full year.
+
+### Middleware
+
+`features_middleware` in `src/server/language.rs` (or inline into the existing `language_middleware`) parses the two cookies, calls `req.extensions_mut().insert(feature_flags)`, then after calling `next.run(req)`, appends two `Set-Cookie` headers to the response to refresh the expiry.
+
+---
+
+## Template Changes
+
+### `templates.rs`
+
+Add `pub features: FeatureFlags` to every template struct:
+- `ErrorTemplate`, `RecipesTemplate`, `RecipeTemplate`, `MenuTemplate`
+- `ShoppingListTemplate`, `PantryTemplate`, `PreferencesTemplate`
+- `EditTemplate`, `NewTemplate`
+
+### `builders.rs`
+
+The builder input structs for recipes/recipe/menu gain a `features: FeatureFlags` field, which is passed through to the constructed template.
+
+### `ui.rs`
+
+Every handler extracts `Extension(features): Extension<FeatureFlags>` and passes it to the template.
+
+---
+
+## `base.html` — Nav links
+
+Inside the existing nav `<div class="order-3 ...">`, before the preferences button, add:
+
+```html
+{% if features.show_shopping_list || features.show_pantry %}
+  <!-- Recipes link (only shown when at least one other feature is enabled) -->
+  <a href="{{ prefix }}{% if static_mode %}/index.html{% endif %}"
+     class="nav-pill {% if active == "recipes" %}active{% endif %}">
+    {{ tr.t("nav-recipes") }}
+  </a>
+
+  {% if features.show_shopping_list && !static_mode %}
+  <a href="{{ prefix }}/shopping-list"
+     class="nav-pill {% if active == "shopping" %}active{% endif %}">
+    {{ tr.t("nav-shopping-list") }}
+  </a>
+  {% endif %}
+
+  {% if features.show_pantry && !static_mode %}
+  <a href="{{ prefix }}/pantry"
+     class="nav-pill {% if active == "pantry" %}active{% endif %}">
+    {{ tr.t("nav-pantry") }}
+  </a>
+  {% endif %}
+{% endif %}
+```
+
+The same conditional block is duplicated in the mobile overflow dropdown.
+
+---
+
+## `preferences.html` — Features section
+
+New card added after the Language section:
+
+```html
+<div class="bg-gradient-to-r from-blue-50 to-indigo-50 p-6 rounded-2xl border-2 border-blue-200">
+    <h2 class="text-lg font-semibold mb-2 text-blue-900">{{ tr.t("pref-features") }}</h2>
+    <p class="text-sm text-blue-700 mb-4">{{ tr.t("pref-features-desc") }}</p>
+    <div class="flex flex-wrap gap-3">
+        <button onclick="toggleFeature('show_shopping_list', {{ features.show_shopping_list }})"
+            class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_shopping_list %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+            {{ tr.t("nav-shopping-list") }}
+        </button>
+        <button onclick="toggleFeature('show_pantry', {{ features.show_pantry }})"
+            class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_pantry %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+            {{ tr.t("nav-pantry") }}
+        </button>
+    </div>
+</div>
+```
+
+JavaScript (same pattern as `setLanguage`):
+
+```js
+function toggleFeature(name, current) {
+    const val = current ? '0' : '1';
+    const maxAge = 365 * 24 * 60 * 60;
+    document.cookie = `${name}=${val}; path={{ prefix }}/; max-age=${maxAge}; SameSite=Lax`;
+    window.location.reload();
+}
+```
+
+---
+
+## Translations
+
+Two new keys added to `preferences.ftl` in all 7 locales:
+
+| Locale  | `pref-features`       | `pref-features-desc`                                              |
+|---------|-----------------------|-------------------------------------------------------------------|
+| en-US   | Features              | Choose which features appear in the navigation bar.               |
+| de-DE   | Funktionen            | Wähle, welche Funktionen in der Navigationsleiste angezeigt werden. |
+| nl-NL   | Functies              | Kies welke functies in de navigatiebalk worden weergegeven.       |
+| fr-FR   | Fonctionnalités       | Choisissez les fonctionnalités à afficher dans la barre de navigation. |
+| es-ES   | Funcionalidades       | Elige qué funciones se muestran en la barra de navegación.        |
+| eu-ES   | Eginbideak            | Aukeratu nabigazio-barran zer eginbide erakutsi nahi duzun.       |
+| sv-SE   | Funktioner            | Välj vilka funktioner som visas i navigeringsfältet.              |
+
+Nav labels (`nav-shopping-list`, `nav-pantry`, `nav-recipes`) already exist in all locales — no changes needed there.
+
+---
+
+## File Checklist
+
+| File | Change |
+|------|--------|
+| `src/server/language.rs` | Add `FeatureFlags` struct + `features_middleware` |
+| `src/server/mod.rs` | Register `features_middleware` in the middleware stack |
+| `src/server/templates.rs` | Add `features: FeatureFlags` to all template structs |
+| `src/server/builders.rs` | Thread `FeatureFlags` through builder inputs/outputs |
+| `src/server/ui.rs` | Extract `Extension(features)` in every handler |
+| `templates/base.html` | Add conditional nav links |
+| `templates/preferences.html` | Add Features section + `toggleFeature` JS |
+| `locales/*/preferences.ftl` (×7) | Add `pref-features` and `pref-features-desc` |

--- a/locales/de-DE/preferences.ftl
+++ b/locales/de-DE/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Gang-Konfiguration hochladen
 pref-upload-pantry = Vorratskammer-Konfiguration hochladen
 pref-upload-success = Konfiguration erfolgreich hochgeladen
 pref-upload-error = Fehler beim Hochladen der Konfiguration
+
+# Features
+pref-features = Funktionen
+pref-features-desc = Wähle, welche Funktionen in der Navigationsleiste angezeigt werden.

--- a/locales/en-US/preferences.ftl
+++ b/locales/en-US/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Upload Aisle Configuration
 pref-upload-pantry = Upload Pantry Configuration
 pref-upload-success = Configuration uploaded successfully
 pref-upload-error = Error uploading configuration
+
+# Features
+pref-features = Features
+pref-features-desc = Choose which features appear in the navigation bar.

--- a/locales/es-ES/preferences.ftl
+++ b/locales/es-ES/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Subir configuración de pasillos
 pref-upload-pantry = Subir configuración de despensa
 pref-upload-success = Configuración subida con éxito
 pref-upload-error = Error al subir la configuración
+
+# Features
+pref-features = Funcionalidades
+pref-features-desc = Elige qué funciones se muestran en la barra de navegación.

--- a/locales/eu-ES/preferences.ftl
+++ b/locales/eu-ES/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Igo pasilloen konfigurazioa
 pref-upload-pantry = Igo despentsaren konfigurazioa
 pref-upload-success = Konfigurazioaren igoera arrakastatsua
 pref-upload-error = Errorea konfigurazioa igotzerakoan
+
+# Features
+pref-features = Eginbideak
+pref-features-desc = Aukeratu nabigazio-barran zer eginbide erakutsi nahi duzun.

--- a/locales/fr-FR/preferences.ftl
+++ b/locales/fr-FR/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Télécharger la configuration des allées
 pref-upload-pantry = Télécharger la configuration du garde-manger
 pref-upload-success = Configuration téléchargée avec succès
 pref-upload-error = Erreur lors du téléchargement de la configuration
+
+# Features
+pref-features = Fonctionnalités
+pref-features-desc = Choisissez les fonctionnalités à afficher dans la barre de navigation.

--- a/locales/nl-NL/preferences.ftl
+++ b/locales/nl-NL/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Gang Configuratie uploaden
 pref-upload-pantry = Voorraadkast Configuratie uploaden
 pref-upload-success = Configuratie succesvol geüpload
 pref-upload-error = Fout bij het uploaden van configuratie
+
+# Features
+pref-features = Functies
+pref-features-desc = Kies welke functies in de navigatiebalk worden weergegeven.

--- a/locales/sv-SE/preferences.ftl
+++ b/locales/sv-SE/preferences.ftl
@@ -21,3 +21,7 @@ pref-upload-aisle = Ladda upp redskap konfiguration
 pref-upload-pantry = Ladda upp skafferi konfiguration
 pref-upload-success = Konfiguration har laddats upp
 pref-upload-error = Fel vid uppladdning av konfiguration
+
+# Features
+pref-features = Funktioner
+pref-features-desc = Välj vilka funktioner som visas i navigeringsfältet.

--- a/src/build/renderer.rs
+++ b/src/build/renderer.rs
@@ -4,6 +4,7 @@ use crate::server::builders::{
     build_recipe_template, build_recipes_template, RecipeBuildInput, RecipeBuildOutput,
     RecipesBuildInput,
 };
+use crate::server::language::FeatureFlags;
 use anyhow::Result;
 use askama::Template;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -24,6 +25,7 @@ pub fn render_index(
         sub_path: None,
         lang: lang.clone(),
         static_mode: true,
+        features: FeatureFlags::default(),
     })?;
     let html = template.render()?;
     write_html(output, &relpath, &html)
@@ -45,6 +47,7 @@ pub fn render_directory(
         sub_path: Some(sub_path),
         lang: lang.clone(),
         static_mode: true,
+        features: FeatureFlags::default(),
     })?;
     let html = template.render()?;
     write_html(output, &relpath, &html)
@@ -88,6 +91,7 @@ pub fn render_recipe(
         scale: 1.0,
         lang: lang.clone(),
         static_mode: true,
+        features: FeatureFlags::default(),
     })?;
 
     match kind {

--- a/src/server/builders.rs
+++ b/src/server/builders.rs
@@ -5,6 +5,7 @@
 //! The builders intentionally avoid any axum / tokio-async types so they can be
 //! reused from a non-async context (e.g. `cook build web`).
 
+use crate::server::language::FeatureFlags;
 use crate::server::templates::*;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -18,6 +19,7 @@ pub struct RecipesBuildInput<'a> {
     pub sub_path: Option<&'a str>,
     pub lang: LanguageIdentifier,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 /// Build a [`RecipesTemplate`] for either the root or a subdirectory.
@@ -28,6 +30,7 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
         sub_path,
         lang,
         static_mode,
+        features,
     } = input;
 
     let search_path = if let Some(p) = sub_path {
@@ -151,6 +154,7 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        features,
     })
 }
 
@@ -163,6 +167,7 @@ pub struct RecipeBuildInput<'a> {
     pub scale: f64,
     pub lang: LanguageIdentifier,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 /// Output of [`build_recipe_template`] — either a regular recipe or a menu.
@@ -181,6 +186,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
         scale,
         lang,
         static_mode,
+        features,
     } = input;
 
     let recipe_path_buf = Utf8PathBuf::from(recipe_path);
@@ -210,6 +216,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
             url_prefix,
             lang,
             static_mode,
+            features,
         )?;
         return Ok(RecipeBuildOutput::Menu(Box::new(template)));
     }
@@ -722,6 +729,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        features,
     };
 
     Ok(RecipeBuildOutput::Recipe(Box::new(template)))
@@ -735,6 +743,7 @@ fn build_menu_template_inner(
     url_prefix: &str,
     lang: LanguageIdentifier,
     static_mode: bool,
+    features: FeatureFlags,
 ) -> Result<MenuTemplate> {
     let recipe = crate::util::parse_recipe_from_entry(&entry, scale)
         .map_err(|e| anyhow::anyhow!("Failed to parse menu: {e}"))?;
@@ -963,6 +972,7 @@ fn build_menu_template_inner(
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        features,
     })
 }
 

--- a/src/server/builders.rs
+++ b/src/server/builders.rs
@@ -735,6 +735,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
     Ok(RecipeBuildOutput::Recipe(Box::new(template)))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_menu_template_inner(
     path: String,
     scale: f64,

--- a/src/server/language.rs
+++ b/src/server/language.rs
@@ -47,9 +47,7 @@ pub fn parse_feature_flags(headers: &HeaderMap) -> FeatureFlags {
                 let parts: Vec<&str> = cookie.trim().splitn(2, '=').collect();
                 if parts.len() == 2 {
                     match parts[0] {
-                        "show_shopping_list" => {
-                            flags.show_shopping_list = parts[1] != "0"
-                        }
+                        "show_shopping_list" => flags.show_shopping_list = parts[1] != "0",
                         "show_pantry" => flags.show_pantry = parts[1] != "0",
                         _ => {}
                     }
@@ -160,15 +158,19 @@ pub async fn features_middleware(
     for (name, val) in [
         (
             "show_shopping_list",
-            if features.show_shopping_list { "1" } else { "0" },
+            if features.show_shopping_list {
+                "1"
+            } else {
+                "0"
+            },
         ),
         ("show_pantry", if features.show_pantry { "1" } else { "0" }),
     ] {
-        let cookie = format!(
-            "{name}={val}; path={cookie_path}; max-age={max_age}; SameSite=Lax"
-        );
+        let cookie = format!("{name}={val}; path={cookie_path}; max-age={max_age}; SameSite=Lax");
         if let Ok(header_val) = cookie.parse() {
-            response.headers_mut().append(header::SET_COOKIE, header_val);
+            response
+                .headers_mut()
+                .append(header::SET_COOKIE, header_val);
         }
     }
 
@@ -194,26 +196,23 @@ mod tests {
 
     #[test]
     fn test_feature_flags_disabled_by_zero() {
-        let flags = parse_feature_flags(&make_cookie_headers(
-            "show_shopping_list=0; show_pantry=0",
-        ));
+        let flags =
+            parse_feature_flags(&make_cookie_headers("show_shopping_list=0; show_pantry=0"));
         assert!(!flags.show_shopping_list);
         assert!(!flags.show_pantry);
     }
 
     #[test]
     fn test_feature_flags_enabled_by_one() {
-        let flags = parse_feature_flags(&make_cookie_headers(
-            "show_shopping_list=1; show_pantry=1",
-        ));
+        let flags =
+            parse_feature_flags(&make_cookie_headers("show_shopping_list=1; show_pantry=1"));
         assert!(flags.show_shopping_list);
         assert!(flags.show_pantry);
     }
 
     #[test]
     fn test_feature_flags_partial_override() {
-        let flags =
-            parse_feature_flags(&make_cookie_headers("show_shopping_list=0"));
+        let flags = parse_feature_flags(&make_cookie_headers("show_shopping_list=0"));
         assert!(!flags.show_shopping_list);
         assert!(flags.show_pantry); // absent → default true
     }
@@ -221,9 +220,7 @@ mod tests {
     #[test]
     fn test_feature_flags_unknown_value_treated_as_enabled() {
         // Anything that isn't "0" is truthy
-        let flags = parse_feature_flags(&make_cookie_headers(
-            "show_shopping_list=yes",
-        ));
+        let flags = parse_feature_flags(&make_cookie_headers("show_shopping_list=yes"));
         assert!(flags.show_shopping_list);
     }
 }

--- a/src/server/language.rs
+++ b/src/server/language.rs
@@ -1,6 +1,6 @@
 use accept_language::parse;
 use axum::{
-    extract::Request,
+    extract::{Request, State},
     http::{header, HeaderMap},
     middleware::Next,
     response::Response,
@@ -18,6 +18,48 @@ pub const SV_SE: LanguageIdentifier = langid!("sv-SE");
 
 pub const SUPPORTED_LANGUAGES: &[LanguageIdentifier] =
     &[EN_US, DE_DE, NL_NL, FR_FR, ES_ES, EU_ES, SV_SE];
+
+/// Per-request feature visibility flags, read from cookies.
+#[derive(Clone, Copy, Debug)]
+pub struct FeatureFlags {
+    pub show_shopping_list: bool,
+    pub show_pantry: bool,
+}
+
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        Self {
+            show_shopping_list: true,
+            show_pantry: true,
+        }
+    }
+}
+
+/// Parse feature flag cookies from request headers.
+/// Absent cookie → feature enabled (default true).
+/// Cookie value "0" → disabled. Any other value → enabled.
+pub fn parse_feature_flags(headers: &HeaderMap) -> FeatureFlags {
+    let mut flags = FeatureFlags::default();
+
+    if let Some(cookie_header) = headers.get(header::COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            for cookie in cookie_str.split(';') {
+                let parts: Vec<&str> = cookie.trim().splitn(2, '=').collect();
+                if parts.len() == 2 {
+                    match parts[0] {
+                        "show_shopping_list" => {
+                            flags.show_shopping_list = parts[1] != "0"
+                        }
+                        "show_pantry" => flags.show_pantry = parts[1] != "0",
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    flags
+}
 
 /// Parse a user-supplied language tag (e.g. "de", "de-DE") into one of the
 /// supported [`LanguageIdentifier`]s. Returns `None` for unsupported tags.
@@ -94,4 +136,94 @@ pub async fn language_middleware(mut req: Request, next: Next) -> Response {
     let lang = get_preferred_language(req.headers());
     req.extensions_mut().insert(lang);
     next.run(req).await
+}
+
+/// Middleware that reads feature flag cookies, injects them as a request
+/// extension, and refreshes the cookie expiry on every response.
+/// Takes the URL prefix as state so Set-Cookie headers use the correct path.
+pub async fn features_middleware(
+    State(url_prefix): State<String>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let features = parse_feature_flags(req.headers());
+    req.extensions_mut().insert(features);
+    let mut response = next.run(req).await;
+
+    let max_age = 365 * 24 * 60 * 60_u32;
+    let cookie_path = if url_prefix.is_empty() {
+        "/".to_string()
+    } else {
+        format!("{url_prefix}/")
+    };
+
+    for (name, val) in [
+        (
+            "show_shopping_list",
+            if features.show_shopping_list { "1" } else { "0" },
+        ),
+        ("show_pantry", if features.show_pantry { "1" } else { "0" }),
+    ] {
+        let cookie = format!(
+            "{name}={val}; path={cookie_path}; max-age={max_age}; SameSite=Lax"
+        );
+        if let Ok(header_val) = cookie.parse() {
+            response.headers_mut().append(header::SET_COOKIE, header_val);
+        }
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cookie_headers(cookies: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::COOKIE, cookies.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn test_feature_flags_default_true_when_no_cookies() {
+        let flags = parse_feature_flags(&HeaderMap::new());
+        assert!(flags.show_shopping_list);
+        assert!(flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_disabled_by_zero() {
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=0; show_pantry=0",
+        ));
+        assert!(!flags.show_shopping_list);
+        assert!(!flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_enabled_by_one() {
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=1; show_pantry=1",
+        ));
+        assert!(flags.show_shopping_list);
+        assert!(flags.show_pantry);
+    }
+
+    #[test]
+    fn test_feature_flags_partial_override() {
+        let flags =
+            parse_feature_flags(&make_cookie_headers("show_shopping_list=0"));
+        assert!(!flags.show_shopping_list);
+        assert!(flags.show_pantry); // absent → default true
+    }
+
+    #[test]
+    fn test_feature_flags_unknown_value_treated_as_enabled() {
+        // Anything that isn't "0" is truthy
+        let flags = parse_feature_flags(&make_cookie_headers(
+            "show_shopping_list=yes",
+        ));
+        assert!(flags.show_shopping_list);
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -192,12 +192,19 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
         Router::new().nest(&state.url_prefix, inner)
     };
 
+    // Capture url_prefix before state is consumed by with_state.
+    let url_prefix_for_features = state.url_prefix.clone();
+
     #[cfg(feature = "sync")]
     let state_for_shutdown = state.clone();
 
     let app = app
         .with_state(state)
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
+        .layer(axum::middleware::from_fn_with_state(
+            url_prefix_for_features,
+            language::features_middleware,
+        ))
         .layer(axum::middleware::from_fn(language::language_middleware))
         .layer(
             CorsLayer::new()

--- a/src/server/templates.rs
+++ b/src/server/templates.rs
@@ -3,6 +3,8 @@ use fluent_templates::Loader;
 use serde::{Deserialize, Serialize};
 use unic_langid::LanguageIdentifier;
 
+use crate::server::language::FeatureFlags;
+
 /// Helper struct for translations in templates
 #[derive(Clone, Debug, Serialize)]
 pub struct Tr {
@@ -44,6 +46,7 @@ pub struct ErrorTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 pub struct TodaysMenu {
@@ -64,6 +67,7 @@ pub struct RecipesTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -82,6 +86,7 @@ pub struct RecipeTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 impl RecipeTemplate {
@@ -382,6 +387,7 @@ pub struct MenuTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -391,6 +397,7 @@ pub struct ShoppingListTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -408,6 +415,7 @@ pub struct PreferencesTemplate {
     pub sync_syncing: bool,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -419,6 +427,7 @@ pub struct PantryTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -432,6 +441,7 @@ pub struct EditTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Template)]
@@ -443,6 +453,7 @@ pub struct NewTemplate {
     pub filename: Option<String>,
     pub prefix: String,
     pub static_mode: bool,
+    pub features: FeatureFlags,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -133,7 +133,12 @@ async fn edit_page(
         .all(|c| matches!(c, Utf8Component::Normal(_)))
     {
         tracing::error!("Invalid path: {path}");
-        return error_page(lang, &state.url_prefix, format!("Invalid path: {path}"), features);
+        return error_page(
+            lang,
+            &state.url_prefix,
+            format!("Invalid path: {path}"),
+            features,
+        );
     }
 
     let recipe_path = Utf8PathBuf::from(&path);

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -1,3 +1,4 @@
+use crate::server::language::FeatureFlags;
 use crate::server::{templates::*, AppState};
 use axum::{
     extract::{Extension, Host, Path, Query, State},
@@ -15,6 +16,7 @@ fn error_page(
     lang: LanguageIdentifier,
     prefix: &str,
     msg: impl std::fmt::Display,
+    features: FeatureFlags,
 ) -> axum::response::Response {
     let template = ErrorTemplate {
         active: String::new(),
@@ -22,6 +24,7 @@ fn error_page(
         tr: Tr::new(lang),
         prefix: prefix.to_string(),
         static_mode: false,
+        features,
     };
     template.into_response()
 }
@@ -41,22 +44,25 @@ pub fn ui() -> Router<Arc<AppState>> {
 async fn recipes_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> axum::response::Response {
-    recipes_handler(state, None, lang).await
+    recipes_handler(state, None, lang, features).await
 }
 
 async fn recipes_directory(
     Path(path): Path<String>,
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> axum::response::Response {
-    recipes_handler(state, Some(path), lang).await
+    recipes_handler(state, Some(path), lang, features).await
 }
 
 async fn recipes_handler(
     state: Arc<AppState>,
     path: Option<String>,
     lang: LanguageIdentifier,
+    features: FeatureFlags,
 ) -> axum::response::Response {
     let input = crate::server::builders::RecipesBuildInput {
         base_path: &state.base_path,
@@ -64,12 +70,13 @@ async fn recipes_handler(
         sub_path: path.as_deref(),
         lang: lang.clone(),
         static_mode: false,
+        features,
     };
     match crate::server::builders::build_recipes_template(input) {
         Ok(template) => template.into_response(),
         Err(e) => {
             tracing::error!("Failed to build recipes template: {:?}", e);
-            error_page(lang, &state.url_prefix, &e)
+            error_page(lang, &state.url_prefix, &e, features)
         }
     }
 }
@@ -84,6 +91,7 @@ async fn recipe_page(
     Query(query): Query<RecipeQuery>,
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> axum::response::Response {
     let scale = query.scale.unwrap_or(1.0);
 
@@ -95,6 +103,7 @@ async fn recipe_page(
         scale,
         lang: lang.clone(),
         static_mode: false,
+        features,
     };
 
     match crate::server::builders::build_recipe_template(input) {
@@ -104,7 +113,7 @@ async fn recipe_page(
         Ok(crate::server::builders::RecipeBuildOutput::Menu(template)) => template.into_response(),
         Err(e) => {
             tracing::error!("Failed to build recipe template: {:?}", e);
-            error_page(lang, &state.url_prefix, &e)
+            error_page(lang, &state.url_prefix, &e, features)
         }
     }
 }
@@ -113,6 +122,7 @@ async fn edit_page(
     Path(path): Path<String>,
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> axum::response::Response {
     tracing::info!("Edit page requested for path: {}", path);
 
@@ -123,7 +133,7 @@ async fn edit_page(
         .all(|c| matches!(c, Utf8Component::Normal(_)))
     {
         tracing::error!("Invalid path: {path}");
-        return error_page(lang, &state.url_prefix, format!("Invalid path: {path}"));
+        return error_page(lang, &state.url_prefix, format!("Invalid path: {path}"), features);
     }
 
     let recipe_path = Utf8PathBuf::from(&path);
@@ -137,6 +147,7 @@ async fn edit_page(
                 lang,
                 &state.url_prefix,
                 format!("Recipe not found: {path}: {e}"),
+                features,
             );
         }
     };
@@ -149,6 +160,7 @@ async fn edit_page(
                 lang,
                 &state.url_prefix,
                 format!("Recipe has no file path: {path}"),
+                features,
             );
         }
     };
@@ -162,6 +174,7 @@ async fn edit_page(
                 lang,
                 &state.url_prefix,
                 format!("Failed to read recipe file: {e}"),
+                features,
             );
         }
     };
@@ -183,6 +196,7 @@ async fn edit_page(
         tr: crate::server::templates::Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        features,
     };
 
     template.into_response()
@@ -197,6 +211,7 @@ struct NewPageQuery {
 async fn new_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
     Query(query): Query<NewPageQuery>,
 ) -> impl askama_axum::IntoResponse {
     crate::server::templates::NewTemplate {
@@ -206,6 +221,7 @@ async fn new_page(
         filename: query.filename,
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        features,
     }
 }
 
@@ -432,18 +448,21 @@ async fn create_recipe(
 async fn shopping_list_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> impl askama_axum::IntoResponse {
     ShoppingListTemplate {
         active: "shopping".to_string(),
         tr: Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        features,
     }
 }
 
 async fn pantry_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> Result<impl askama_axum::IntoResponse, StatusCode> {
     // Load pantry configuration
     let pantry_path = state.pantry_path.as_ref();
@@ -485,12 +504,14 @@ async fn pantry_page(
         tr: Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        features,
     })
 }
 
 async fn preferences_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
+    Extension(features): Extension<FeatureFlags>,
 ) -> impl askama_axum::IntoResponse {
     #[cfg(feature = "sync")]
     let (sync_logged_in, sync_email, sync_syncing) = state.sync_status().await;
@@ -518,5 +539,6 @@ async fn preferences_page(
         sync_syncing,
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        features,
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,6 +185,21 @@
             color: #a78bfa !important;
         }
 
+        /* Nav pill dark mode */
+        .dark .nav-pill {
+            color: #9ca3af;
+        }
+
+        .dark .nav-pill:hover {
+            background: #374151;
+            color: #fb923c;
+        }
+
+        .dark .nav-pill.active {
+            background: linear-gradient(135deg, #ff6b35, #f97316);
+            color: white;
+        }
+
         /* Button dark mode styles */
         .dark .bg-gray-200 {
             background-color: #4b5563;
@@ -771,18 +786,25 @@
                     </div>
 
                     <div class="order-3 w-full md:w-auto flex items-center gap-1 lg:gap-2">
-                        <a href="{{ prefix }}/{% if static_mode %}index.html{% endif %}" class="px-3 lg:px-5 py-2 rounded-full font-medium whitespace-nowrap text-sm lg:text-base transition-all duration-300 {% if active == "recipes" %}bg-gradient-to-r from-orange-500 to-amber-500 text-white font-bold shadow-lg scale-105{% else %}text-gray-600 hover:bg-gradient-to-r hover:from-orange-100 hover:to-amber-100 hover:text-orange-700 hover:shadow-md hover:-translate-y-0.5{% endif %}">
-                            <span>{{ tr.t("nav-recipes") }}</span>
-                        </a>
-                        {% if !static_mode %}
-                        <a href="{{ prefix }}/shopping-list" class="px-3 lg:px-5 py-2 rounded-full font-medium whitespace-nowrap text-sm lg:text-base transition-all duration-300 {% if active == "shopping" %}bg-gradient-to-r from-purple-500 to-pink-500 text-white font-bold shadow-lg scale-105{% else %}text-gray-600 hover:bg-gradient-to-r hover:from-purple-100 hover:to-pink-100 hover:text-purple-700 hover:shadow-md hover:-translate-y-0.5{% endif %}">
-                            <span>{{ tr.t("nav-shopping-list") }}</span>
-                        </a>
-                        {% endif %}
-                        {% if !static_mode %}
-                        <a href="{{ prefix }}/pantry" class="px-3 lg:px-5 py-2 rounded-full font-medium whitespace-nowrap text-sm lg:text-base transition-all duration-300 {% if active == "pantry" %}bg-gradient-to-r from-green-500 to-teal-500 text-white font-bold shadow-lg scale-105{% else %}text-gray-600 hover:bg-gradient-to-r hover:from-green-100 hover:to-teal-100 hover:text-green-700 hover:shadow-md hover:-translate-y-0.5{% endif %}">
-                            <span>{{ tr.t("nav-pantry") }}</span>
-                        </a>
+                        {% if features.show_shopping_list || features.show_pantry %}
+                        <div class="hidden md:flex items-center gap-1 mr-2 lg:mr-4">
+                            <a href="{{ prefix }}/{% if static_mode %}index.html{% endif %}"
+                               class="nav-pill {% if active == "recipes" %}active{% endif %}">
+                                {{ tr.t("nav-recipes") }}
+                            </a>
+                            {% if features.show_shopping_list && !static_mode %}
+                            <a href="{{ prefix }}/shopping-list"
+                               class="nav-pill {% if active == "shopping" %}active{% endif %}">
+                                {{ tr.t("nav-shopping-list") }}
+                            </a>
+                            {% endif %}
+                            {% if features.show_pantry && !static_mode %}
+                            <a href="{{ prefix }}/pantry"
+                               class="nav-pill {% if active == "pantry" %}active{% endif %}">
+                                {{ tr.t("nav-pantry") }}
+                            </a>
+                            {% endif %}
+                        </div>
                         {% endif %}
                         <!-- Inline buttons on md+ screens -->
                         {% if !static_mode %}
@@ -811,6 +833,22 @@
                                 </svg>
                             </button>
                             <div id="more-dropdown" class="hidden absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-xl z-50 py-1">
+                                {% if features.show_shopping_list || features.show_pantry %}
+                                <a href="{{ prefix }}/{% if static_mode %}index.html{% endif %}" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "recipes" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🍳</span> <span>{{ tr.t("nav-recipes") }}</span>
+                                </a>
+                                {% if features.show_shopping_list && !static_mode %}
+                                <a href="{{ prefix }}/shopping-list" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "shopping" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🛒</span> <span>{{ tr.t("nav-shopping-list") }}</span>
+                                </a>
+                                {% endif %}
+                                {% if features.show_pantry && !static_mode %}
+                                <a href="{{ prefix }}/pantry" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors {% if active == "pantry" %}font-semibold text-orange-600{% endif %}">
+                                    <span>🥫</span> <span>{{ tr.t("nav-pantry") }}</span>
+                                </a>
+                                {% endif %}
+                                <div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
+                                {% endif %}
                                 {% if !static_mode %}
                                 <a href="{{ prefix }}/preferences" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                                     <span>⚙️</span> <span>Preferences</span>

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -43,6 +43,24 @@
             <p class="text-sm text-purple-700 mt-3">Your language preference will be saved in a cookie.</p>
         </div>
 
+        <!-- Features -->
+        {% if !static_mode %}
+        <div class="bg-gradient-to-r from-blue-50 to-indigo-50 p-6 rounded-2xl border-2 border-blue-200">
+            <h2 class="text-lg font-semibold mb-2 text-blue-900">{{ tr.t("pref-features") }}</h2>
+            <p class="text-sm text-blue-700 mb-4">{{ tr.t("pref-features-desc") }}</p>
+            <div class="flex flex-wrap gap-3">
+                <button onclick="toggleFeature('show_shopping_list', {{ features.show_shopping_list }})"
+                        class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_shopping_list %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+                    🛒 {{ tr.t("nav-shopping-list") }}
+                </button>
+                <button onclick="toggleFeature('show_pantry', {{ features.show_pantry }})"
+                        class="px-4 py-2 rounded-lg font-medium transition-all duration-200 border-2 {% if features.show_pantry %}bg-gradient-to-r from-orange-500 to-orange-600 text-white border-orange-600 shadow-lg scale-105{% else %}bg-white text-gray-700 border-gray-300 hover:border-orange-400 hover:bg-orange-50 hover:scale-105{% endif %}">
+                    🥫 {{ tr.t("nav-pantry") }}
+                </button>
+            </div>
+        </div>
+        {% endif %}
+
         <!-- CookCloud Sync -->
         {% if sync_enabled %}
         <div class="bg-gray-50 p-4 rounded">
@@ -166,6 +184,13 @@
 
 {% block scripts %}
 <script>
+    function toggleFeature(name, current) {
+        const val = current ? '0' : '1';
+        const maxAge = 365 * 24 * 60 * 60;
+        document.cookie = `${name}=${val}; path={{ prefix }}/; max-age=${maxAge}; SameSite=Lax`;
+        window.location.reload();
+    }
+
     function setLanguage(lang) {
         // Set cookie for 1 year
         const maxAge = 365 * 24 * 60 * 60;

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -151,3 +151,66 @@ test.describe('Navigation', () => {
     await expect(recipeTitle).toContainText('Sicilian-style Scottadito Lamb Chops');
   });
 });
+
+test.describe('Feature flag nav visibility', () => {
+  test.beforeEach(async ({ context }) => {
+    // Reset both feature flags to default (enabled) before each test
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '1', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '1', url: 'http://localhost:9080' },
+    ]);
+  });
+
+  test('shows Recipes, Shopping List, and Pantry nav links by default', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).toBeVisible();
+  });
+
+  test('hides Shopping List nav link when cookie is 0', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).not.toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).toBeVisible();
+  });
+
+  test('hides Pantry nav link when cookie is 0', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_pantry', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Pantry/i })).not.toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Recipes/i })).toBeVisible();
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+  });
+
+  test('shows no nav pills when both features are disabled', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill')).toHaveCount(0);
+  });
+
+  test('nav pill is active on its corresponding page', async ({ page }) => {
+    await page.goto('/shopping-list');
+    await page.waitForLoadState('domcontentloaded');
+
+    const shoppingPill = page.locator('nav a.nav-pill.active');
+    await expect(shoppingPill).toBeVisible();
+    await expect(shoppingPill).toContainText(/Shopping/i);
+  });
+});

--- a/tests/e2e/preferences.spec.ts
+++ b/tests/e2e/preferences.spec.ts
@@ -209,3 +209,56 @@ olive_oil = { amount = "1", unit = "l" }
     }
   });
 });
+
+test.describe('Feature toggles in preferences', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '1', url: 'http://localhost:9080' },
+      { name: 'show_pantry', value: '1', url: 'http://localhost:9080' },
+    ]);
+  });
+
+  test('displays Features section with two active buttons', async ({ page }) => {
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    const shoppingBtn = page.getByRole('button', { name: /Shopping/i });
+    const pantryBtn = page.getByRole('button', { name: /Pantry/i });
+
+    await expect(shoppingBtn).toBeVisible();
+    await expect(pantryBtn).toBeVisible();
+
+    // Both enabled → should have the active (orange gradient) classes
+    await expect(shoppingBtn).toHaveClass(/from-orange-500/);
+    await expect(pantryBtn).toHaveClass(/from-orange-500/);
+  });
+
+  test('toggling Shopping List off removes it from nav', async ({ page }) => {
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /Shopping/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Button is now inactive
+    const shoppingBtn = page.getByRole('button', { name: /Shopping/i });
+    await expect(shoppingBtn).not.toHaveClass(/from-orange-500/);
+
+    // Nav no longer shows Shopping List
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).not.toBeVisible();
+  });
+
+  test('toggling a feature back on restores the nav link', async ({ context, page }) => {
+    await context.addCookies([
+      { name: 'show_shopping_list', value: '0', url: 'http://localhost:9080' },
+    ]);
+    await page.goto('/preferences');
+    await page.waitForLoadState('networkidle');
+
+    // Shopping is currently off — click to enable
+    await page.getByRole('button', { name: /Shopping/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('nav a.nav-pill', { hasText: /Shopping/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Goal

Let users choose which features appear in the nav bar via the Preferences page. Shopping List and Pantry are shown by default (opt-out). Recipes is always the home page and cannot be hidden. If only Recipes is enabled, no nav links are shown at all (the bar still shows search, preferences, and theme toggle).
This implements #327 

<img width="1152" height="196" alt="image" src="https://github.com/user-attachments/assets/92a0ccbf-2d49-4a01-9405-3c8bb7dbbb86" />
<img width="1155" height="99" alt="image" src="https://github.com/user-attachments/assets/c79f2190-6980-4360-bc39-339c1498153c" />


## Approach: Cookie-based, server-side rendering

Feature flags are stored as cookies, read in middleware, and injected as an Axum extension — exactly mirroring how the `lang` cookie and `LanguageIdentifier` extension work today. Askama templates render conditionally; no JS is needed for the nav itself.
Specs and implementation plans have been added in docs/

Disclaimer: The implementation has been done using Claude Code. I made the designs decisions and have reviewed the code.