### PR TITLE
chore: bump cooklang-language-server to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "cooklang-language-server"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4f0ec7cf3dba205edeacb9868413fb43dda06d9c3bfd5d7b74d71273a04ebb"
+checksum = "debf28fcbfd9161a365f488e38460d7890664abfe61e4d4d555087d383760c89"
 dependencies = [
  "anyhow",
  "cooklang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ cooklang-find = { version = "0.6" }
 cooklang-import = "0.9.3"
 cooklang-sync-client = { version = "0.4.11", optional = true }
 libsqlite3-sys = { version = "0.35", features = ["bundled"], optional = true }
-cooklang-language-server = "0.2.1"
+cooklang-language-server = "0.2.3"
 cooklang-reports = { version = "0.2.2" }
 directories = "6"
 fluent = "0.16"


### PR DESCRIPTION
Bumps `cooklang-language-server` 0.2.1 → 0.2.3 to pick up the multi-word ingredient/cookware/timer parsing fix, so `cook lsp` correctly highlights and shows tooltips for names with spaces or punctuation (e.g. `@heavy whipping cream{1%cup}`).

Depends on cooklang/cooklang-language-server#8 being released to crates.io first (the `Cargo.lock` entry will resolve once 0.2.3 is published).

Relates to cooklang/CookVSCode#10