### PR TITLE
feat: respect prefers-color-scheme for selecting server theme

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,8 +12,9 @@
     <link href="{{ prefix }}/static/css/output.css" rel="stylesheet">
     <link href="{{ prefix }}/static/css/custom-styles.css" rel="stylesheet">
     <script>
-        // Check for saved theme preference or default to light
-        const theme = localStorage.getItem('theme') || 'light';
+        // Check for saved theme preference, or check for prefers-color-scheme, or default to light
+        const theme = localStorage.getItem('theme')
+            || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
         document.documentElement.classList.toggle('dark', theme === 'dark');
     </script>
     <style>


### PR DESCRIPTION
Check if the user has a preference for a light or dark color theme, using [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme)