### PR TITLE
fix(build): use thin LTO to cut peak build memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,5 +124,6 @@ regex = "1"
 
 [profile.release]
 strip = true
-lto = true
-codegen-units = 1
+# Fat LTO with codegen-units = 1 needs a multi-GB heap to link this dependency
+# graph, which OOMs on low-memory ARM boards. See #366.
+lto = "thin"


### PR DESCRIPTION
Fixes the `cargo install` failure reported in #366.

## Problem

```
error: failed to load bitcode of module "cooklang_find-...cgu.0.rcgu.o":
```

That message is emitted from exactly one place in rustc — the **fat LTO** path (`run_fat` in `rustc_codegen_llvm/src/back/lto.rs`). We opt into it ourselves:

```toml
[profile.release]
lto = true          # fat LTO
codegen-units = 1
```

Fat LTO with `codegen-units = 1` is the highest-peak-memory codegen configuration available, and we apply it across a ~400 crate graph. Note the reporter's error ends with `":` and an *empty* LLVM message — LLVM was handed a buffer that is not valid bitcode (a truncated `.rlib`), rather than hitting a codegen bug, which would print a concrete diagnostic like `Invalid cast`.

The truncation has a clear source on their platform: `cargo install` writes its target dir under `$TMPDIR` (hence `/tmp/cargo-installwdiPPp`), and **Armbian mounts `/tmp` on zram — RAM-backed, sized to RAM/2** by default ([armbian-zram-config](https://github.com/armbian/build/blob/main/packages/bsp/common/usr/lib/armbian/armbian-zram-config)). So 1.3 GB of build artifacts land in RAM on a board that simultaneously needs a multi-GB heap for fat LTO.

## Change

`lto = "thin"`, and drop the `codegen-units = 1` pin (back to the release default of 16). Thin LTO keeps most of the cross-crate optimisation benefit without the fat-LTO memory cliff, and restores codegen parallelism.

## Verification

Release build succeeds; resulting binary is 23 MB on aarch64-apple-darwin. I did not complete a clean fat-LTO size comparison locally, so if binary size is a hard constraint here, worth checking CI's artifact sizes before merging — some size regression is expected and is the intended trade for not OOMing on a 1–2 GB SBC.

Refs #366