### PR TITLE
docs: steer low-memory installs to prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,33 @@ brew install cookcli
 If you have Rust installed:
 
 ```bash
-cargo install cookcli
+cargo install cookcli --locked
 ```
+
+`--locked` builds against the dependency versions we tested and released with, rather than re-resolving to the newest compatible ones.
+
+Note that this compiles CookCLI and all its dependencies from source, which needs a few GB of RAM and disk. If you are on a Raspberry Pi, an Armbian board, or anything else memory-constrained, prefer the [prebuilt binaries](https://github.com/cooklang/CookCLI/releases) — we publish `aarch64` and `armv7` Linux builds.
+
+<details>
+<summary>Building on a low-memory single-board computer</summary>
+
+`cargo install` places its build directory under `$TMPDIR`. On Armbian, `/tmp` is mounted on zram — a RAM-backed device sized to half your RAM — so a multi-gigabyte build will exhaust memory and fail, sometimes with a confusing `failed to load bitcode of module ...` error.
+
+Point the build somewhere on real storage:
+
+```bash
+CARGO_TARGET_DIR=~/.cache/cookcli-build cargo install cookcli --locked
+```
+
+If memory is still tight, disable link-time optimisation for the build:
+
+```bash
+CARGO_PROFILE_RELEASE_LTO=false \
+CARGO_TARGET_DIR=~/.cache/cookcli-build \
+  cargo install cookcli --locked
+```
+
+</details>
 
 ### Build from Source
 


### PR DESCRIPTION
Addresses the install side of #366.

We already publish `aarch64-unknown-linux-musl` and `arm-unknown-linux-musleabihf` binaries in `release.yaml` — but the README presents `cargo install cookcli` as a peer option with no caveats, so SBC users reach for it and then spend an hour compiling ~400 crates only to run out of RAM.

Changes to the Installation section:
- `cargo install cookcli` → `cargo install cookcli --locked`, with a note on why.
- Say plainly that installing via cargo compiles from source and needs a few GB, and point memory-constrained users at the prebuilt binaries we already ship.
- A collapsed section documenting the Armbian trap: `/tmp` is zram-backed (sized RAM/2) and `cargo install` puts its target dir there, which is what produces the confusing `failed to load bitcode of module ...` failure. Gives the `CARGO_TARGET_DIR` and `CARGO_PROFILE_RELEASE_LTO=false` escape hatches.

Pairs with #367, which fixes the underlying memory cliff by moving off fat LTO.

Refs #366