### PR TITLE
fix: satisfy clippy::useless_borrows_in_formatting (unbreaks CI)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -176,7 +176,7 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
         );
     }
 
-    println!("Serving recipe files from: {:?}", &state.base_path);
+    println!("Serving recipe files from: {:?}", state.base_path);
 
     // Maximum request body size: 1MB (reasonable for recipe files)
     const MAX_BODY_SIZE: usize = 1024 * 1024;

--- a/src/util/cooklang_to_cooklang.rs
+++ b/src/util/cooklang_to_cooklang.rs
@@ -115,7 +115,7 @@ fn w_step(w: &mut impl io::Write, step: &Step, recipe: &Recipe) -> Result<()> {
                         sep,
                         reference.components.join(&sep),
                         sep,
-                        &igr.name
+                        igr.name
                     )
                 } else {
                     igr.name.clone()


### PR DESCRIPTION
**CI on `main` is broken, and every open PR is red because of it — including a docs-only one.** This is the fix.

## Cause

The `Test` workflow installs `stable` and runs `cargo clippy -- -D warnings`. Stable has since moved to Rust 1.97, which added [`useless_borrows_in_formatting`](https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting). It fires on two pre-existing sites:

- `src/server/mod.rs:179` — `println!("...{:?}", &state.base_path)`
- `src/util/cooklang_to_cooklang.rs:118` — `&igr.name` as a `format!` argument

Nothing changed in the repo. `main`'s last green run was 1 July; the toolchain moved underneath it. Clippy's failure is the *first* step in the job, so builds and tests never even run — which is why #367, #368 and #369 all report `Test fail` despite passing locally.

## Change

Drop the two redundant references. No behaviour change: `Display`/`Debug` are implemented for both the value and the reference, so the formatted output is identical.

## Verification

Reproduced the failure on `main` with a pinned 1.97 toolchain, then confirmed the fix against the same toolchain CI uses:

- `cargo +1.97 clippy --all-targets -- -D warnings` — 0 issues (default **and** `--no-default-features`)
- `cargo +1.97 fmt --check` — clean
- `cargo +1.97 test` — 13 suites pass

Worth merging first — the other PRs cannot show green until this lands.
