### PR TITLE
fix(deps): declare cooklang's bundled_units feature explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,11 @@ camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 base64 = { version = "0.22", optional = true }
-cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "pantry", "shopping_list"] }
+# bundled_units carries the unit database (quantity scaling, unit normalisation).
+# We rely on it in `cook recipe`, but never declared it: it was reaching us only
+# via feature unification from cooklang-language-server / cooklang-reports, which
+# depend on cooklang with default features. Declare it where it is actually used.
+cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "bundled_units", "pantry", "shopping_list"] }
 cooklang-find = { version = "0.6" }
 cooklang-import = "0.9.3"
 cooklang-sync-client = { version = "0.4.11", optional = true }


### PR DESCRIPTION
Split out of #369 so it can land on its own — it fixes a latent correctness issue that exists on `main` right now, independent of any refactoring.

## The bug

`bundled_units` is the `cooklang` feature carrying the unit database — it is what makes quantities scalable and normalises units. `cook recipe` depends on it.

**cookcli never declared it.** Our manifest says:

```toml
cooklang = { default-features = false, features = ["aisle", "pantry", "shopping_list"] }
```

The feature has been arriving purely through Cargo **feature unification**: `cooklang-language-server` and `cooklang-reports` both depend on `cooklang` with *default* features, and `cooklang`'s defaults include `bundled_units`. We have been getting it by accident.

That means any dependency change which drops those crates from the graph silently changes recipe output:

```diff
   "quantity": {
-    "scalable": true,
-    "unit": "cups",
+    "scalable": false,
+    "unit": "c",
```

Nothing about that is obvious from our manifest, and nothing warns you. I only found it because gating `lsp` off in #369 dropped `cooklang-language-server` and the snapshot tests went red.

## The fix

Declare `bundled_units` in our own `cooklang` dependency, where it is actually used.

## Verification — this is a no-op today

The point of the change is that it is invisible now and load-bearing later. Confirmed on aarch64:

| | resolved `cooklang` features | crates |
|---|---|---|
| `main` | aisle, **bundled_units**, default, pantry, prettyplease, quote, shopping_list, syn, sync, toml, toml_edit | 412 |
| this PR | *identical* | 412 |

- `cargo test` — 13 suites pass, snapshots unchanged (recipe output byte-identical)
- No new dependencies, no size change

Needs #370 to land first for CI to go green (clippy is broken on `main` by the Rust 1.97 toolchain bump).

Refs #366
