### PR TITLE
chore(deps): bump cooklang-language-server to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "cooklang-language-server"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "debf28fcbfd9161a365f488e38460d7890664abfe61e4d4d555087d383760c89"
+checksum = "193ebb7121bdd55fc189baebdbcd689fdc638820fc7b826b01fe3e1aca6c77c0"
 dependencies = [
  "anyhow",
  "cooklang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ cooklang-find = { version = "0.6.1", default-features = false }
 cooklang-import = { version = "0.9.3", optional = true }
 cooklang-sync-client = { version = "0.4.11", optional = true }
 libsqlite3-sys = { version = "0.35", features = ["bundled"], optional = true }
-cooklang-language-server = { version = "0.2.3", optional = true }
+cooklang-language-server = { version = "0.2.4", optional = true }
 cooklang-reports = { version = "0.5.1" }
 directories = "6"
 fluent = "0.16"


### PR DESCRIPTION
Picks up cooklang/cooklang-language-server#9, which stops the language server enabling `cooklang`'s `bundled_units` feature — it only parses and diagnoses, and never used the unit database.

## Why this is the interesting one

**Before #371, this bump would have silently broken `cook recipe`.**

We were getting `bundled_units` purely by accident: we never declared it, and it reached us through cargo feature unification because `cooklang-language-server` depended on `cooklang` with default features. Take that away — exactly what the upstream fix does — and recipe output changes underneath you:

```diff
   "quantity": {
-    "scalable": true,
-    "unit": "cups",
+    "scalable": false,
+    "unit": "c",
```

No warning, no compile error. Just different output.

Since #371 declares `bundled_units` on our own `cooklang` dependency, where it is actually used, this bump is a **no-op for behaviour**:

- `cargo tree -e features -i cooklang` — `bundled_units` still enabled
- `cargo test` — 13 suites pass, **snapshots unchanged** (recipe output byte-identical)

That is the whole point of #371, demonstrated.

## Crate count

Unchanged at 396. We genuinely want the unit database, so the `toml`/`syn`/`prettyplease`/`quote` codegen chain stays — the upstream change stops it being *forced* on consumers who do not want it, which is a win for everyone else depending on the language server, not for us.

## Verification (CI toolchain, 1.97)
- `cargo clippy --all-targets -- -D warnings` — 0 issues
- `cargo fmt --check` — clean
- `cargo test` — 13 suites pass

Refs #366
