### PR TITLE
feat(recipe): add --paper-size and --margin flags for LaTeX/Typst output

### DIFF
--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -22,6 +22,8 @@ cook recipe [OPTIONS] [RECIPE]
 | `-s, --scale <SCALE>` | Scaling factor for ingredient quantities (default: 1) |
 | `-o, --output <FILE>` | Output file (format inferred from extension) |
 | `--pretty` | Pretty-print JSON and YAML output |
+| `-p, --paper-size <SIZE>` | Paper size for `latex`/`typst` output: `a4` (default), `letter`, `a5`, `legal` |
+| `-m, --margin <CM>` | Page margin in centimeters for `latex`/`typst` output, applied to all sides (default: 2.5) |
 
 ## Examples
 
@@ -37,6 +39,9 @@ cook recipe "Neapolitan Pizza" -f json --pretty
 
 # Save as Markdown
 cook recipe "Neapolitan Pizza" -f markdown -o pizza.md
+
+# Export as LaTeX with US Letter paper and 3cm margins
+cook recipe "Neapolitan Pizza" -f latex --paper-size letter --margin 3 -o pizza.tex
 
 # Read from stdin
 cat recipe.cook | cook recipe

--- a/src/recipe/read.rs
+++ b/src/recipe/read.rs
@@ -74,6 +74,46 @@ pub struct ReadArgs {
     /// Has no effect on human, cooklang, or markdown formats.
     #[arg(long)]
     pretty: bool,
+
+    /// Paper size for LaTeX and Typst output (default: a4)
+    ///
+    /// Has no effect on other formats.
+    #[arg(short = 'p', long, value_enum)]
+    paper_size: Option<PaperSize>,
+
+    /// Page margin in centimeters for LaTeX and Typst output (default: 2.5)
+    ///
+    /// Applied equally to all four sides. Has no effect on other formats.
+    #[arg(short, long)]
+    margin: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PaperSize {
+    A4,
+    Letter,
+    A5,
+    Legal,
+}
+
+impl PaperSize {
+    fn latex_name(self) -> &'static str {
+        match self {
+            PaperSize::A4 => "a4paper",
+            PaperSize::Letter => "letterpaper",
+            PaperSize::A5 => "a5paper",
+            PaperSize::Legal => "legalpaper",
+        }
+    }
+
+    fn typst_name(self) -> &'static str {
+        match self {
+            PaperSize::A4 => "a4",
+            PaperSize::Letter => "us-letter",
+            PaperSize::A5 => "a5",
+            PaperSize::Legal => "us-legal",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -142,6 +182,18 @@ pub fn run(ctx: &Context, args: ReadArgs) -> Result<()> {
         None => OutputFormat::Human,
     });
 
+    if !matches!(format, OutputFormat::Latex | OutputFormat::Typst) {
+        if args.paper_size.is_some() {
+            eprintln!("warning: --paper-size has no effect with the selected output format");
+        }
+        if args.margin.is_some() {
+            eprintln!("warning: --margin has no effect with the selected output format");
+        }
+    }
+
+    let paper_size = args.paper_size.unwrap_or(PaperSize::A4);
+    let margin = args.margin.unwrap_or(2.5);
+
     write_to_output(args.output.as_deref(), |writer| {
         match format {
             OutputFormat::Human => crate::util::cooklang_to_human::print_human(
@@ -175,6 +227,8 @@ pub fn run(ctx: &Context, args: ReadArgs) -> Result<()> {
                 scale,
                 PARSER.converter(),
                 writer,
+                paper_size.latex_name(),
+                margin,
             )?,
             OutputFormat::Typst => crate::util::cooklang_to_typst::print_typst(
                 &recipe,
@@ -182,6 +236,8 @@ pub fn run(ctx: &Context, args: ReadArgs) -> Result<()> {
                 scale,
                 PARSER.converter(),
                 writer,
+                paper_size.typst_name(),
+                margin,
             )?,
             OutputFormat::Schema => crate::util::cooklang_to_schema::print_schema(
                 &recipe,

--- a/src/util/cooklang_to_latex.rs
+++ b/src/util/cooklang_to_latex.rs
@@ -12,8 +12,10 @@ pub fn print_latex(
     scale: f64,
     converter: &Converter,
     mut writer: impl io::Write,
+    paper_size: &str,
+    margin: f64,
 ) -> Result<()> {
-    write_document_header(&mut writer)?;
+    write_document_header(&mut writer, paper_size, margin)?;
 
     writeln!(writer, "% BEGIN_RECIPE_CONTENT")?;
 
@@ -43,8 +45,8 @@ pub fn print_latex(
     Ok(())
 }
 
-fn write_document_header(w: &mut impl io::Write) -> Result<()> {
-    writeln!(w, r"\documentclass[11pt,a4paper]{{article}}")?;
+fn write_document_header(w: &mut impl io::Write, paper_size: &str, margin: f64) -> Result<()> {
+    writeln!(w, r"\documentclass[11pt,{paper_size}]{{article}}")?;
     writeln!(w, r"\usepackage[utf8]{{inputenc}}")?;
     writeln!(w, r"\usepackage[T1]{{fontenc}}")?;
     writeln!(w, r"\usepackage{{lmodern}}")?;
@@ -60,7 +62,7 @@ fn write_document_header(w: &mut impl io::Write) -> Result<()> {
     writeln!(w)?;
     writeln!(
         w,
-        r"\geometry{{left=2.5cm,right=2.5cm,top=2.5cm,bottom=2.5cm}}"
+        r"\geometry{{left={margin}cm,right={margin}cm,top={margin}cm,bottom={margin}cm}}"
     )?;
     writeln!(w)?;
     writeln!(w, r"% Define colors for recipe elements")?;

--- a/src/util/cooklang_to_typst.rs
+++ b/src/util/cooklang_to_typst.rs
@@ -12,8 +12,10 @@ pub fn print_typst(
     scale: f64,
     converter: &Converter,
     mut writer: impl io::Write,
+    paper_size: &str,
+    margin: f64,
 ) -> Result<()> {
-    write_document_header(&mut writer)?;
+    write_document_header(&mut writer, paper_size, margin)?;
 
     writeln!(writer)?;
     writeln!(writer, "// BEGIN_RECIPE_CONTENT")?;
@@ -44,10 +46,10 @@ pub fn print_typst(
     Ok(())
 }
 
-fn write_document_header(w: &mut impl io::Write) -> Result<()> {
+fn write_document_header(w: &mut impl io::Write, paper_size: &str, margin: f64) -> Result<()> {
     writeln!(
         w,
-        r#"#set page(paper: "a4", margin: (left: 2.5cm, right: 2.5cm, top: 2.5cm, bottom: 2.5cm))"#
+        r#"#set page(paper: "{paper_size}", margin: (left: {margin}cm, right: {margin}cm, top: {margin}cm, bottom: {margin}cm))"#
     )?;
     writeln!(w)?;
     writeln!(w, r"#set text(size: 11pt)")?;

--- a/tests/output_formats_test.rs
+++ b/tests/output_formats_test.rs
@@ -69,6 +69,131 @@ fn test_recipe_markdown_output() {
 }
 
 #[test]
+fn test_recipe_latex_default_paper_size_and_margin() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("latex")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r"\documentclass[11pt,a4paper]{article}",
+        ))
+        .stdout(predicate::str::contains(
+            r"\geometry{left=2.5cm,right=2.5cm,top=2.5cm,bottom=2.5cm}",
+        ));
+}
+
+#[test]
+fn test_recipe_latex_custom_paper_size() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("latex")
+        .arg("--paper-size")
+        .arg("letter")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r"\documentclass[11pt,letterpaper]{article}",
+        ));
+}
+
+#[test]
+fn test_recipe_latex_custom_margin() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("latex")
+        .arg("--margin")
+        .arg("3")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r"\geometry{left=3cm,right=3cm,top=3cm,bottom=3cm}",
+        ));
+}
+
+#[test]
+fn test_recipe_typst_default_paper_size_and_margin() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("typst")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#"#set page(paper: "a4", margin: (left: 2.5cm, right: 2.5cm, top: 2.5cm, bottom: 2.5cm))"#,
+        ));
+}
+
+#[test]
+fn test_recipe_typst_custom_paper_size_and_margin() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("typst")
+        .arg("--paper-size")
+        .arg("letter")
+        .arg("--margin")
+        .arg("3")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#"#set page(paper: "us-letter", margin: (left: 3cm, right: 3cm, top: 3cm, bottom: 3cm))"#,
+        ));
+}
+
+#[test]
+fn test_recipe_paper_size_warns_for_unrelated_format() {
+    let temp_dir = common::setup_test_recipes().unwrap();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("recipe")
+        .arg("read")
+        .arg("-f")
+        .arg("json")
+        .arg("--paper-size")
+        .arg("letter")
+        .arg("simple.cook")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("--paper-size"));
+}
+
+#[test]
 fn test_recipe_cooklang_output() {
     let temp_dir = common::setup_test_recipes().unwrap();
 


### PR DESCRIPTION
## Summary
- Adds `-p, --paper-size <a4|letter|a5|legal>` and `-m, --margin <CM>` flags to `cook recipe read`
- Applied to both LaTeX and Typst output, which previously hardcoded `a4` paper and 2.5cm margins with no way to override them
- Passing these flags with any other output format prints a warning to stderr and is otherwise a no-op

Fixes #379

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including new tests for default/custom paper size/margin on both formats, and the unrelated-format warning)