### PR TITLE
feat(build): add --repo-url flag to link the source repo from the site footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ cook build web dist --base-path ~/my-recipes
 
 # Build for hosting under a subpath
 cook build web --base-url /recipes/
+
+# Link back to the recipe repository from the footer
+cook build web --repo-url https://github.com/user/my-recipes
 ```
 
 ### `cook search`

--- a/docs/build.md
+++ b/docs/build.md
@@ -24,6 +24,7 @@ cook build web [OPTIONS] [OUTPUT_DIR]
 |--------|-------------|
 | `--base-path <PATH>` | Root directory containing recipe files (default: current directory) |
 | `--base-url <URL>` | Absolute URL prefix for hosting under a subpath (e.g. `/recipes/`). When unset, links are page-relative and the site works under any prefix, including `file://`. |
+| `--repo-url <URL>` | URL of the recipe repository. When set, the footer's "Built with CookCLI" line gains a "View source" link pointing here. |
 
 ## Examples
 
@@ -36,6 +37,9 @@ cook build web dist --base-path ~/my-recipes
 
 # Build for hosting under /recipes/ on your domain
 cook build web --base-url /recipes/
+
+# Link back to the recipe repository from the footer
+cook build web --repo-url https://github.com/user/my-recipes
 ```
 
 ## What gets generated

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -72,6 +72,13 @@ pub struct WebBuildArgs {
     /// is independent of --base-url. Omit it to skip sitemap generation.
     #[arg(long)]
     pub sitemap: Option<String>,
+
+    /// URL of the recipe repository, linked from the site footer
+    ///
+    /// When set, the generated footer's "Built with CookCLI" line gains a
+    /// "View source" link pointing here. Omit it to skip the link.
+    #[arg(long)]
+    pub repo_url: Option<String>,
 }
 
 fn parse_lang_arg(s: &str) -> Result<LanguageIdentifier, String> {
@@ -133,7 +140,17 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
         }
     }
 
-    renderer::render_index(&source, &output, base_url, &lang)?;
+    // Validate the repo URL up front for the same reason as --sitemap above.
+    let repo_url = args.repo_url.as_deref();
+    if let Some(repo) = repo_url {
+        let parsed =
+            url::Url::parse(repo).with_context(|| format!("Invalid --repo-url URL: {repo}"))?;
+        if parsed.host().is_none() || !matches!(parsed.scheme(), "http" | "https") {
+            bail!("--repo-url must be an absolute http(s) URL, e.g. https://github.com/user/repo");
+        }
+    }
+
+    renderer::render_index(&source, &output, base_url, repo_url, &lang)?;
 
     let mut tree = cooklang_find::build_tree(&source)
         .map_err(|e| anyhow::anyhow!("Failed to build recipe tree: {e}"))?;
@@ -144,7 +161,15 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     // and `_site/api/static/...` one level deeper until the OS rejects the
     // path length.
     prune_output_subtree(&mut tree, &output);
-    walk_directories(&tree, &source, &output, base_url, &lang, String::new())?;
+    walk_directories(
+        &tree,
+        &source,
+        &output,
+        base_url,
+        repo_url,
+        &lang,
+        String::new(),
+    )?;
 
     let aisle = ctx.aisle();
     let recipe_count = walk_recipes(
@@ -153,6 +178,7 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
         &output,
         aisle.as_ref(),
         base_url,
+        repo_url,
         &lang,
         String::new(),
     )?;
@@ -233,6 +259,7 @@ fn walk_directories(
     source: &camino::Utf8Path,
     output: &camino::Utf8Path,
     base_url: Option<&str>,
+    repo_url: Option<&str>,
     lang: &unic_langid::LanguageIdentifier,
     prefix_path: String,
 ) -> Result<()> {
@@ -245,18 +272,20 @@ fn walk_directories(
         } else {
             format!("{prefix_path}/{name}")
         };
-        renderer::render_directory(source, output, &sub, base_url, lang)?;
-        walk_directories(child, source, output, base_url, lang, sub)?;
+        renderer::render_directory(source, output, &sub, base_url, repo_url, lang)?;
+        walk_directories(child, source, output, base_url, repo_url, lang, sub)?;
     }
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn walk_recipes(
     tree: &cooklang_find::RecipeTree,
     source: &camino::Utf8Path,
     output: &camino::Utf8Path,
     aisle_path: Option<&camino::Utf8PathBuf>,
     base_url: Option<&str>,
+    repo_url: Option<&str>,
     lang: &unic_langid::LanguageIdentifier,
     prefix_path: String,
 ) -> Result<usize> {
@@ -275,7 +304,7 @@ fn walk_recipes(
                 format!("{prefix_path}/{leaf_name}")
             };
             if let Err(e) =
-                renderer::render_recipe(source, output, &sub, aisle_path, base_url, lang)
+                renderer::render_recipe(source, output, &sub, aisle_path, base_url, repo_url, lang)
             {
                 tracing::warn!("Skipping recipe {sub}: {e:#}");
                 continue;
@@ -292,7 +321,9 @@ fn walk_recipes(
             } else {
                 format!("{prefix_path}/{name}")
             };
-            count += walk_recipes(child, source, output, aisle_path, base_url, lang, sub)?;
+            count += walk_recipes(
+                child, source, output, aisle_path, base_url, repo_url, lang, sub,
+            )?;
         }
     }
     Ok(count)

--- a/src/build/renderer.rs
+++ b/src/build/renderer.rs
@@ -15,6 +15,7 @@ pub fn render_index(
     source: &Utf8Path,
     output: &Utf8Path,
     base_url: Option<&str>,
+    repo_url: Option<&str>,
     lang: &LanguageIdentifier,
 ) -> Result<()> {
     let relpath = Utf8PathBuf::from("index.html");
@@ -25,6 +26,7 @@ pub fn render_index(
         sub_path: None,
         lang: lang.clone(),
         static_mode: true,
+        repo_url: repo_url.map(String::from),
         features: FeatureFlags::default(),
     })?;
     let html = template.render()?;
@@ -37,6 +39,7 @@ pub fn render_directory(
     output: &Utf8Path,
     sub_path: &str,
     base_url: Option<&str>,
+    repo_url: Option<&str>,
     lang: &LanguageIdentifier,
 ) -> Result<()> {
     let relpath = Utf8PathBuf::from(format!("directory/{sub_path}.html"));
@@ -47,6 +50,7 @@ pub fn render_directory(
         sub_path: Some(sub_path),
         lang: lang.clone(),
         static_mode: true,
+        repo_url: repo_url.map(String::from),
         features: FeatureFlags::default(),
     })?;
     let html = template.render()?;
@@ -72,6 +76,7 @@ pub fn render_recipe(
     recipe_relpath: &str,
     aisle_path: Option<&Utf8PathBuf>,
     base_url: Option<&str>,
+    repo_url: Option<&str>,
     lang: &LanguageIdentifier,
 ) -> Result<()> {
     let trimmed = recipe_relpath
@@ -91,6 +96,7 @@ pub fn render_recipe(
         scale: 1.0,
         lang: lang.clone(),
         static_mode: true,
+        repo_url: repo_url.map(String::from),
         features: FeatureFlags::default(),
     })?;
 

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -25,6 +25,7 @@ fn error_page(
         tr: Tr::new(lang),
         prefix: prefix.to_string(),
         static_mode: false,
+        repo_url: None,
         features,
     };
     template.into_response()
@@ -71,6 +72,7 @@ async fn recipes_handler(
         sub_path: path.as_deref(),
         lang: lang.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     };
     match crate::web::builders::build_recipes_template(input) {
@@ -104,6 +106,7 @@ async fn recipe_page(
         scale,
         lang: lang.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     };
 
@@ -200,6 +203,7 @@ async fn edit_page(
         tr: crate::web::templates::Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     };
 
@@ -225,6 +229,7 @@ async fn new_page(
         filename: query.filename,
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     }
 }
@@ -459,6 +464,7 @@ async fn shopping_list_page(
         tr: Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     }
 }
@@ -508,6 +514,7 @@ async fn pantry_page(
         tr: Tr::new(lang),
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     })
 }
@@ -543,6 +550,7 @@ async fn preferences_page(
         sync_syncing,
         prefix: state.url_prefix.clone(),
         static_mode: false,
+        repo_url: None,
         features,
     }
 }

--- a/src/web/builders.rs
+++ b/src/web/builders.rs
@@ -19,6 +19,7 @@ pub struct RecipesBuildInput<'a> {
     pub sub_path: Option<&'a str>,
     pub lang: LanguageIdentifier,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -30,6 +31,7 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
         sub_path,
         lang,
         static_mode,
+        repo_url,
         features,
     } = input;
 
@@ -182,6 +184,7 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        repo_url,
         features,
     })
 }
@@ -195,6 +198,7 @@ pub struct RecipeBuildInput<'a> {
     pub scale: f64,
     pub lang: LanguageIdentifier,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -214,6 +218,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
         scale,
         lang,
         static_mode,
+        repo_url,
         features,
     } = input;
 
@@ -244,6 +249,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
             url_prefix,
             lang,
             static_mode,
+            repo_url,
             features,
         )?;
         return Ok(RecipeBuildOutput::Menu(Box::new(template)));
@@ -757,6 +763,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        repo_url,
         features,
     };
 
@@ -772,6 +779,7 @@ fn build_menu_template_inner(
     url_prefix: &str,
     lang: LanguageIdentifier,
     static_mode: bool,
+    repo_url: Option<String>,
     features: FeatureFlags,
 ) -> Result<MenuTemplate> {
     let recipe = crate::util::parse_recipe_from_entry(&entry, scale)
@@ -1001,6 +1009,7 @@ fn build_menu_template_inner(
         tr: Tr::new(lang),
         prefix: url_prefix.to_string(),
         static_mode,
+        repo_url,
         features,
     })
 }

--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -68,6 +68,7 @@ pub struct ErrorTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -89,6 +90,7 @@ pub struct RecipesTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -108,6 +110,7 @@ pub struct RecipeTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -409,6 +412,7 @@ pub struct MenuTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -420,6 +424,7 @@ pub struct ShoppingListTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -439,6 +444,7 @@ pub struct PreferencesTemplate {
     pub sync_syncing: bool,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -452,6 +458,7 @@ pub struct PantryTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -467,6 +474,7 @@ pub struct EditTemplate {
     pub tr: Tr,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 
@@ -480,6 +488,7 @@ pub struct NewTemplate {
     pub filename: Option<String>,
     pub prefix: String,
     pub static_mode: bool,
+    pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -879,6 +879,10 @@
         <footer class="mt-12 mb-6 text-center text-sm text-gray-500 print:hidden">
             Built with
             <a href="https://cooklang.org/cli/" class="text-orange-600 hover:text-orange-700 hover:underline" target="_blank" rel="noopener">CookCLI</a>
+            {% if let Some(url) = repo_url %}
+            &middot;
+            <a href="{{ url }}" class="text-orange-600 hover:text-orange-700 hover:underline" target="_blank" rel="noopener">View source</a>
+            {% endif %}
         </footer>
         {% endif %}
     </div>

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -187,6 +188,92 @@ fn build_writes_recipe_pages() {
         html.contains("\"recipeInstructions\""),
         "JSON-LD should include recipeInstructions list"
     );
+}
+
+#[test]
+fn build_omits_repo_link_when_repo_url_not_set() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let index = std::fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(
+        !index.contains("View source"),
+        "no repo link should be present without --repo-url"
+    );
+}
+
+#[test]
+fn build_writes_repo_link_when_repo_url_set() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+            "--repo-url",
+            "https://github.com/cooklang/cookcli",
+        ])
+        .assert()
+        .success();
+
+    let index = std::fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(
+        index.contains(r#"href="https://github.com/cooklang/cookcli""#),
+        "footer should link to the repo URL"
+    );
+    assert!(
+        index.contains("View source"),
+        "footer should label the repo link"
+    );
+
+    // Recipe pages should carry the same link, not just the index.
+    let pancakes = out.join("recipe/Breakfast/Easy Pancakes.html");
+    let html = std::fs::read_to_string(&pancakes).unwrap();
+    assert!(
+        html.contains(r#"href="https://github.com/cooklang/cookcli""#),
+        "recipe page footer should also link to the repo URL"
+    );
+}
+
+#[test]
+fn build_repo_url_rejects_invalid_url() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+            "--repo-url",
+            "not-a-url",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--repo-url"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `--repo-url <URL>` to `cook build web`
- When set, the generated site footer's "Built with CookCLI" line gains a "View source" link pointing to the given repository URL, on every page (index, directory listings, recipes, and menus)
- Validated as an absolute http(s) URL, mirroring the existing `--sitemap` validation
- Scoped to `cook build web` only, matching the issue — the footer link only ever renders in static-site output (`static_mode`), never in `cook server`

Fixes #376

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including new tests: link present with `--repo-url`, absent without it, and invalid URLs are rejected)