### PR TITLE
fix(server): wrap long ingredient notes instead of clipping them

### DIFF
--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -237,7 +237,7 @@
                                     {% endmatch %}
                                     {% match ingredient.note %}
                                     {% when Some with (note) %}
-                                        <span class="text-sm text-gray-600 italic ml-1 truncate max-w-xs inline-block" title="{{ note }}" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>
+                                        <span class="text-sm text-gray-600 italic ml-1 break-words" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>
                                     {% when None %}
                                     {% endmatch %}
                                 </div>
@@ -277,7 +277,7 @@
                             {% endmatch %}
                             {% match ingredient.note %}
                             {% when Some with (note) %}
-                                <span class="text-sm text-gray-600 italic ml-1 truncate max-w-xs inline-block" title="{{ note }}" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>
+                                <span class="text-sm text-gray-600 italic ml-1 break-words" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>
                             {% when None %}
                             {% endmatch %}
                         </div>
@@ -337,7 +337,7 @@
                                                 <div class="text-sm text-gray-600 mt-2 pl-4 border-l-2 border-orange-300">
                                                     {% for ing in step.ingredients %}
                                                         <span class="inline-block mr-3">
-                                                            {{ ing.name }}{% match ing.quantity %}{% when Some with (q) %}: {{ q }}{% when None %}{% endmatch %}{% match ing.unit %}{% when Some with (u) %} {{ u }}{% when None %}{% endmatch %}{% match ing.note %}{% when Some with (note) %} <span class="italic text-gray-600 truncate max-w-[200px] inline-block align-bottom" title="{{ note }}" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>{% when None %}{% endmatch %}{% if !loop.last %},{% endif %}
+                                                            {{ ing.name }}{% match ing.quantity %}{% when Some with (q) %}: {{ q }}{% when None %}{% endmatch %}{% match ing.unit %}{% when Some with (u) %} {{ u }}{% when None %}{% endmatch %}{% match ing.note %}{% when Some with (note) %} <span class="italic text-gray-600 break-words" aria-label="{{ tr.t("recipe-preparation") }}: {{ note }}">({{ note }})</span>{% when None %}{% endmatch %}{% if !loop.last %},{% endif %}
                                                         </span>
                                                     {% endfor %}
                                                 </div>

--- a/tests/e2e/recipe-display.spec.ts
+++ b/tests/e2e/recipe-display.spec.ts
@@ -154,11 +154,10 @@ test.describe('Recipe Display', () => {
 
       // Check accessibility attributes
       await expect(noteSpan).toHaveAttribute('aria-label');
-      await expect(noteSpan).toHaveAttribute('title');
 
-      // Check truncation classes are present for long notes
-      await expect(noteSpan).toHaveClass(/truncate/);
-      await expect(noteSpan).toHaveClass(/max-w-/);
+      // Long notes wrap instead of being truncated (issue #375)
+      await expect(noteSpan).toHaveClass(/break-words/);
+      await expect(noteSpan).not.toHaveClass(/truncate/);
     }
 
     // Check step-level ingredient notes
@@ -166,8 +165,8 @@ test.describe('Recipe Display', () => {
     if (await stepIngredients.count() > 0) {
       const stepNoteSpan = stepIngredients.locator('span.italic').first();
       if (await stepNoteSpan.count() > 0) {
-        await expect(stepNoteSpan).toHaveAttribute('title');
         await expect(stepNoteSpan).toHaveAttribute('aria-label');
+        await expect(stepNoteSpan).not.toHaveClass(/truncate/);
       }
     }
   });


### PR DESCRIPTION
## Summary
- Ingredient notes (shorthand like `@onion{1}(peeled and finely diced...)`) were rendered with Tailwind's `truncate` class plus a max-width cap (`max-w-xs` in the ingredients section, `max-w-[200px]` in the per-step ingredient summary), so longer notes were clipped with an ellipsis.
- Replaced the truncation classes with `break-words` so notes wrap naturally, and removed the `title` attribute whose only purpose was revealing the clipped text (the `aria-label` remains).

Fixes #375

## Testing
- Rebuilt Tailwind output (`npm run build-css`) to confirm `break-words` is included in the compiled CSS.
- Served a test recipe with a ~130-character ingredient note and verified via the rendered HTML that both the ingredients section and the step summary show the full note with no truncation.
- `cargo fmt`, `cargo clippy`, and `cargo test` all pass cleanly.