### PR TITLE
feat(build): default site language to the system locale and document --lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "strip-ansi-escapes 0.2.1",
+ "sys-locale",
  "tabular",
  "tempfile",
  "textwrap",
@@ -3709,6 +3710,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ self_update = { version = "0.41", default-features = false, features = ["archive
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
+sys-locale = "0.3"
 tabular = { version = "0.2", features = ["ansi-cell"] }
 textwrap = { version = "0.16", features = ["terminal_size"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -103,6 +103,7 @@ pub enum Command {
     ///   cook build web out                     # Build to ./out
     ///   cook build web --base-path ~/recipes   # Use specific source directory
     ///   cook build web --base-url /recipes/    # Absolute URL prefix for subpath hosting
+    ///   cook build web --lang fr-FR            # Render the site in French
     #[command(long_about = "Build artifacts (static website, etc.) from your recipe collection")]
     Build(build::BuildArgs),
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -5,7 +5,7 @@ mod sitemap;
 mod writer;
 
 use crate::util::resolve_to_absolute_path;
-use crate::web::language::{parse_supported_language, EN_US};
+use crate::web::language::{parse_supported_language, system_language};
 use crate::Context;
 use anyhow::{bail, Context as _, Result};
 use camino::Utf8PathBuf;
@@ -26,11 +26,17 @@ pub enum BuildCommand {
     /// host or directly from disk via file://. Excludes dynamic features
     /// (shopping list, pantry, editing).
     ///
+    /// Unlike `cook server`, which picks a language per request from the
+    /// browser's Accept-Language header, the static site is rendered in a
+    /// single language chosen at build time via `--lang` (default: the
+    /// system locale, falling back to en-US).
+    ///
     /// Examples:
     ///   cook build web                         # Build to ./_site
     ///   cook build web out                     # Build to ./out
     ///   cook build web --base-path ~/recipes   # Use specific source directory
     ///   cook build web --base-url /recipes/    # Absolute URL prefix for subpath hosting
+    ///   cook build web --lang fr-FR            # Render the site in French
     Web(WebBuildArgs),
 }
 
@@ -55,7 +61,12 @@ pub struct WebBuildArgs {
     #[arg(long)]
     pub base_url: Option<String>,
 
-    /// UI language for the generated site (default: en-US)
+    /// UI language for the generated site
+    ///
+    /// The static site is rendered in a single language chosen at build
+    /// time (unlike `cook server`, which negotiates per request from the
+    /// browser's Accept-Language header). Defaults to the system locale,
+    /// falling back to en-US.
     ///
     /// Accepts a BCP-47 tag like `de-DE`, or a bare language code like `de`
     /// that matches a supported region. Supported: en-US, de-DE, nl-NL,
@@ -120,9 +131,9 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
 
     let output = resolve_to_absolute_path(&output_raw)?;
 
-    println!("Building static site from {source} into {output}");
+    let lang = args.lang.clone().unwrap_or_else(system_language);
 
-    let lang = args.lang.clone().unwrap_or(EN_US);
+    println!("Building static site from {source} into {output} (language: {lang})");
     let base_url = args.base_url.as_deref();
 
     // Validate the sitemap URL up front so a typo fails fast, before spending

--- a/src/web/language.rs
+++ b/src/web/language.rs
@@ -77,6 +77,33 @@ pub fn parse_supported_language(s: &str) -> Option<LanguageIdentifier> {
         .cloned()
 }
 
+/// Map an OS locale tag to a supported language, falling back to en-US.
+///
+/// Accepts both BCP-47 tags ("fr-FR") and POSIX-style tags as found in
+/// LANG/LC_ALL ("fr_FR.UTF-8", "de_DE@euro").
+pub fn language_from_system_locale(locale: Option<String>) -> LanguageIdentifier {
+    locale
+        .as_deref()
+        .map(|tag| {
+            let tag = tag.split(['.', '@']).next().unwrap_or(tag);
+            tag.replace('_', "-")
+        })
+        .and_then(|tag| parse_supported_language(&tag))
+        .unwrap_or(EN_US)
+}
+
+/// Detect the system locale and map it to a supported language,
+/// falling back to en-US.
+///
+/// POSIX locale env vars take precedence over the OS-level locale
+/// (on macOS `sys_locale` reads system preferences, not the environment).
+pub fn system_language() -> LanguageIdentifier {
+    let env_locale = ["LC_ALL", "LC_MESSAGES", "LANG"]
+        .iter()
+        .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()));
+    language_from_system_locale(env_locale.or_else(sys_locale::get_locale))
+}
+
 /// Get the preferred language from headers
 /// 1. Check for 'lang' cookie
 /// 2. Parse Accept-Language header
@@ -181,6 +208,47 @@ pub async fn features_middleware(
     }
 
     response
+}
+
+#[cfg(test)]
+mod locale_tests {
+    use super::*;
+
+    #[test]
+    fn test_system_locale_bcp47_tag() {
+        assert_eq!(language_from_system_locale(Some("fr-FR".into())), FR_FR);
+    }
+
+    #[test]
+    fn test_system_locale_posix_tag_with_encoding() {
+        assert_eq!(
+            language_from_system_locale(Some("fr_FR.UTF-8".into())),
+            FR_FR
+        );
+    }
+
+    #[test]
+    fn test_system_locale_posix_tag_with_modifier() {
+        assert_eq!(
+            language_from_system_locale(Some("de_DE@euro".into())),
+            DE_DE
+        );
+    }
+
+    #[test]
+    fn test_system_locale_bare_language_code() {
+        assert_eq!(language_from_system_locale(Some("sv".into())), SV_SE);
+    }
+
+    #[test]
+    fn test_system_locale_unsupported_falls_back_to_english() {
+        assert_eq!(language_from_system_locale(Some("ja-JP".into())), EN_US);
+    }
+
+    #[test]
+    fn test_system_locale_missing_falls_back_to_english() {
+        assert_eq!(language_from_system_locale(None), EN_US);
+    }
 }
 
 #[cfg(all(test, feature = "server"))]


### PR DESCRIPTION
## Summary
Addresses the discoverability gaps from #384:

- `cook build web` now defaults its UI language to the **system locale** instead of always `en-US` — POSIX env vars (`LC_ALL`, `LC_MESSAGES`, `LANG`) take precedence, then the OS-level locale via the new `sys-locale` dependency (needed because on macOS the OS locale lives in system preferences, not the environment). Unsupported or undetectable locales still fall back to `en-US`, and `--lang` overrides everything.
- The build output now prints the chosen language (`Building static site from ... (language: fr-FR)`) so the single-language-at-build-time behavior is visible.
- Added `cook build web --lang fr-FR` to the command examples in `src/args.rs` and `src/build/mod.rs`, and expanded the `--lang` help text to explain that the server negotiates per request while the static build renders one language chosen at build time.

A companion PR updates the docs at cooklang.org with a Localization section.

Fixes #384

## Testing
- 6 new unit tests for the locale-tag mapping (`fr-FR`, `fr_FR.UTF-8`, `de_DE@euro`, bare `sv`, unsupported `ja-JP` → `en-US`, missing → `en-US`), written first and confirmed red before implementing.
- End-to-end: built a test collection with `LC_ALL=fr_FR.UTF-8` (renders "Ingrédients"), `LC_ALL=C` (renders English), and `--lang sv` under a C locale (renders "Ingredienser").
- `cargo fmt`, `cargo clippy`, and `cargo test` all pass cleanly.