### PR TITLE
fix(server): resolve section-style step image names (Recipe.S.N.ext)

### DIFF
--- a/src/web/builders.rs
+++ b/src/web/builders.rs
@@ -381,7 +381,7 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
     }
 
     let mut total_steps = 0;
-    for section in &recipe.sections {
+    for (section_index, section) in recipe.sections.iter().enumerate() {
         let mut section_items = Vec::new();
         let mut section_ingredient_indices = std::collections::HashSet::new();
         let mut cooking_mode_ingredient_indices: Vec<usize> = Vec::new();
@@ -491,9 +491,14 @@ pub fn build_recipe_template(input: RecipeBuildInput<'_>) -> Result<RecipeBuildO
                         }
                     }
 
+                    // Step images come in two naming conventions (issue #374):
+                    // `Recipe.S.N.ext` (section S, step N within it — used by the
+                    // iOS app) and `Recipe.N.ext` (step N counted continuously
+                    // across sections). Prefer the section-specific image.
                     let section_image_path = entry
                         .step_images()
-                        .get(0, total_steps + step_count + 1)
+                        .get(section_index + 1, step_count + 1)
+                        .or_else(|| entry.step_images().get(0, total_steps + step_count + 1))
                         .and_then(|img_path| {
                             get_image_path(base_path, url_prefix, img_path.to_string())
                         });

--- a/tests/step_images_test.rs
+++ b/tests/step_images_test.rs
@@ -1,0 +1,118 @@
+// Step image resolution for sectioned recipes (issue #374).
+//
+// Two naming conventions exist for step images:
+// - Linear:  Recipe.N.ext   where N counts steps continuously across sections
+// - Sectioned: Recipe.S.N.ext  where S is the section and N the step within it
+//
+// cooklang-find indexes both; the web builder must resolve either.
+
+use camino::Utf8Path;
+use cookcli::web::builders::{build_recipe_template, RecipeBuildInput, RecipeBuildOutput};
+use cookcli::web::language::{FeatureFlags, EN_US};
+use cookcli::web::templates::{RecipeSectionItem, RecipeTemplate};
+
+const TWO_SECTION_RECIPE: &str =
+    "= Prep\n\nChop the @onion{1}.\n\n= Cook\n\nFry the onion in @oil{1%tbsp}.\n";
+
+fn build(dir: &Utf8Path, recipe_name: &str) -> RecipeTemplate {
+    let output = build_recipe_template(RecipeBuildInput {
+        base_path: dir,
+        url_prefix: "",
+        recipe_path: recipe_name,
+        aisle_path: None,
+        scale: 1.0,
+        lang: EN_US,
+        static_mode: false,
+        repo_url: None,
+        features: FeatureFlags::default(),
+    })
+    .expect("failed to build recipe template");
+
+    match output {
+        RecipeBuildOutput::Recipe(template) => *template,
+        RecipeBuildOutput::Menu(_) => panic!("expected a recipe, got a menu"),
+    }
+}
+
+fn step_image_paths(template: &RecipeTemplate) -> Vec<Option<String>> {
+    template
+        .sections
+        .iter()
+        .flat_map(|s| s.items.iter())
+        .filter_map(|item| match item {
+            RecipeSectionItem::Step(step) => Some(step.image_path.clone()),
+            RecipeSectionItem::Note(_) => None,
+        })
+        .collect()
+}
+
+#[test]
+fn linear_step_images_resolve_across_sections() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = Utf8Path::from_path(tmp.path()).unwrap();
+    std::fs::write(dir.join("Linear.cook"), TWO_SECTION_RECIPE).unwrap();
+    std::fs::write(dir.join("Linear.1.jpg"), []).unwrap();
+    std::fs::write(dir.join("Linear.2.jpg"), []).unwrap();
+
+    let images = step_image_paths(&build(dir, "Linear"));
+    assert_eq!(images.len(), 2);
+    assert!(
+        images[0].as_deref().unwrap_or("").ends_with("Linear.1.jpg"),
+        "step 1 should show Linear.1.jpg, got {:?}",
+        images[0]
+    );
+    assert!(
+        images[1].as_deref().unwrap_or("").ends_with("Linear.2.jpg"),
+        "step 2 (section 2) should show Linear.2.jpg, got {:?}",
+        images[1]
+    );
+}
+
+#[test]
+fn sectioned_step_images_resolve_per_section() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = Utf8Path::from_path(tmp.path()).unwrap();
+    std::fs::write(dir.join("Sectioned.cook"), TWO_SECTION_RECIPE).unwrap();
+    std::fs::write(dir.join("Sectioned.1.1.jpg"), []).unwrap();
+    std::fs::write(dir.join("Sectioned.2.1.jpg"), []).unwrap();
+
+    let images = step_image_paths(&build(dir, "Sectioned"));
+    assert_eq!(images.len(), 2);
+    assert!(
+        images[0]
+            .as_deref()
+            .unwrap_or("")
+            .ends_with("Sectioned.1.1.jpg"),
+        "section 1 step 1 should show Sectioned.1.1.jpg, got {:?}",
+        images[0]
+    );
+    assert!(
+        images[1]
+            .as_deref()
+            .unwrap_or("")
+            .ends_with("Sectioned.2.1.jpg"),
+        "section 2 step 1 should show Sectioned.2.1.jpg, got {:?}",
+        images[1]
+    );
+}
+
+#[test]
+fn section_convention_wins_over_linear_for_same_step() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = Utf8Path::from_path(tmp.path()).unwrap();
+    std::fs::write(dir.join("Mixed.cook"), TWO_SECTION_RECIPE).unwrap();
+    // Both conventions present for the second step (section 2, global step 2).
+    std::fs::write(dir.join("Mixed.2.jpg"), []).unwrap();
+    std::fs::write(dir.join("Mixed.2.1.jpg"), []).unwrap();
+
+    let images = step_image_paths(&build(dir, "Mixed"));
+    assert_eq!(images.len(), 2);
+    assert!(
+        images[1]
+            .as_deref()
+            .unwrap_or("")
+            .ends_with("Mixed.2.1.jpg"),
+        "the section-specific image should win, got {:?}",
+        images[1]
+    );
+}


### PR DESCRIPTION
## Summary
Fixes the step-image naming discrepancy between the CLI server and the iOS app (#374).

`cooklang-find`'s `StepImageCollection` already indexes both conventions — `Recipe.N.ext` (step N counted continuously across sections) at section bucket 0, and `Recipe.S.N.ext` (section S, step N within it, as used by the iOS app) at bucket S-1. But the web builder only ever queried `get(0, continuous_step)`, so section-style names never resolved.

The builder now tries the section-specific lookup first and falls back to the continuous one:

```rust
entry.step_images()
    .get(section_index + 1, step_count + 1)
    .or_else(|| entry.step_images().get(0, total_steps + step_count + 1))
```

Both conventions now work in `cook server` and `cook build web` (they share this builder), and the section-specific image wins when both exist for the same step. Backward compatible — existing linear-named collections resolve exactly as before (for section 1 the two lookups are identical, since cooklang-find stores section 1 and linear names in the same bucket).

Fixes #374

## Testing
New integration test `tests/step_images_test.rs` covering a two-section recipe (written first, confirmed red):
- linear names `Linear.1.jpg`/`Linear.2.jpg` resolve across sections (passed before the fix)
- section names `Sectioned.1.1.jpg`/`Sectioned.2.1.jpg` resolve per section (failed before, passes now)
- when both exist, the section-specific image wins

`cargo fmt`, `cargo clippy`, and the full `cargo test` suite pass cleanly.