### PR TITLE
feat(build): add --compress flag to write gzip copies of generated assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "cooklang-reports",
  "cooklang-sync-client",
  "directories",
+ "flate2",
  "fluent",
  "fluent-templates",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ libsqlite3-sys = { version = "0.35", features = ["bundled"], optional = true }
 cooklang-language-server = { version = "0.2.4", optional = true }
 cooklang-reports = { version = "0.5.1" }
 directories = "6"
+flate2 = "1"
 fluent = "0.16"
 futures-util = { version = "0.3", optional = true }
 fluent-templates = "0.10"
@@ -116,7 +117,9 @@ yansi = "1"
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"
+flate2 = "1"
 predicates = "3"
+walkdir = "2"
 insta = { version = "1", features = ["yaml", "json", "filters"] }
 strip-ansi-escapes = "0.2"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,7 @@ pub enum Command {
     ///   cook build web --base-path ~/recipes   # Use specific source directory
     ///   cook build web --base-url /recipes/    # Absolute URL prefix for subpath hosting
     ///   cook build web --lang fr-FR            # Render the site in French
+    ///   cook build web --compress              # Also write .gz copies for precompressed hosting
     #[command(long_about = "Build artifacts (static website, etc.) from your recipe collection")]
     Build(build::BuildArgs),
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -37,6 +37,7 @@ pub enum BuildCommand {
     ///   cook build web --base-path ~/recipes   # Use specific source directory
     ///   cook build web --base-url /recipes/    # Absolute URL prefix for subpath hosting
     ///   cook build web --lang fr-FR            # Render the site in French
+    ///   cook build web --compress              # Also write .gz copies for precompressed hosting
     Web(WebBuildArgs),
 }
 
@@ -90,6 +91,14 @@ pub struct WebBuildArgs {
     /// "View source" link pointing here. Omit it to skip the link.
     #[arg(long)]
     pub repo_url: Option<String>,
+
+    /// Also write gzip-compressed copies (.gz) of generated text assets
+    ///
+    /// Writes a `<file>.gz` next to every HTML, CSS, JS, JSON, XML, SVG and
+    /// .cook file so static hosts that support precompressed assets (e.g.
+    /// GitLab Pages) can serve them directly. Images are skipped.
+    #[arg(long)]
+    pub compress: bool,
 }
 
 fn parse_lang_arg(s: &str) -> Result<LanguageIdentifier, String> {
@@ -214,9 +223,16 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
         false
     };
 
+    let compressed_note = if args.compress {
+        let compressed_count = writer::compress_output(&output)?;
+        format!(", {compressed_count} files compressed")
+    } else {
+        String::new()
+    };
+
     let sitemap_note = if sitemap_written { ", sitemap.xml" } else { "" };
     println!(
-        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries{sitemap_note}"
+        "Wrote index, directories, {recipe_count} recipe pages, {image_count} images, {asset_count} static assets, {entry_count} search entries{sitemap_note}{compressed_note}"
     );
     Ok(())
 }

--- a/src/build/writer.rs
+++ b/src/build/writer.rs
@@ -72,6 +72,59 @@ pub fn copy_recipe_source(
     Ok(())
 }
 
+/// File extensions worth precompressing. Images, fonts and other binary
+/// formats are already compressed and are skipped.
+const COMPRESSIBLE_EXTENSIONS: &[&str] =
+    &["html", "css", "js", "json", "xml", "svg", "txt", "cook"];
+
+/// Write a gzip-compressed sibling (`<file>.gz`) for every compressible file
+/// under `output_root`, for static hosts that serve precompressed assets
+/// (e.g. GitLab Pages). A `.gz` is only written when it is actually smaller
+/// than the original. Returns the number of files compressed.
+pub fn compress_output(output_root: &Utf8Path) -> Result<usize> {
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
+
+    let mut count = 0;
+    for entry in walkdir::WalkDir::new(output_root) {
+        let entry = entry.with_context(|| format!("Failed to walk: {output_root}"))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let compressible = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| {
+                COMPRESSIBLE_EXTENSIONS
+                    .iter()
+                    .any(|c| ext.eq_ignore_ascii_case(c))
+            });
+        if !compressible {
+            continue;
+        }
+
+        let contents =
+            fs::read(path).with_context(|| format!("Failed to read: {}", path.display()))?;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder
+            .write_all(&contents)
+            .with_context(|| format!("Failed to compress: {}", path.display()))?;
+        let compressed = encoder
+            .finish()
+            .with_context(|| format!("Failed to compress: {}", path.display()))?;
+
+        // Only keep the .gz when it actually saves space; hosts fall back to
+        // the uncompressed file when no sibling .gz exists.
+        if compressed.len() < contents.len() {
+            let dest = format!("{}.gz", path.display());
+            fs::write(&dest, compressed).with_context(|| format!("Failed to write: {dest}"))?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -593,3 +593,124 @@ fn build_twice_with_output_inside_source_does_not_recurse() {
         "output should not contain a nested _site after repeated builds: {nested:?}"
     );
 }
+
+#[test]
+fn build_compress_writes_gzip_variants() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+            "--compress",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compressed"));
+
+    // Text assets get a sibling .gz whose contents decompress to the original.
+    for file in [
+        "index.html",
+        "static/css/output.css",
+        "static/search-index.json",
+    ] {
+        let gz_path = out.join(format!("{file}.gz"));
+        assert!(gz_path.is_file(), "{file}.gz should exist");
+
+        let mut decoder = flate2::read::GzDecoder::new(std::fs::File::open(&gz_path).unwrap());
+        let mut decompressed = Vec::new();
+        std::io::Read::read_to_end(&mut decoder, &mut decompressed).unwrap();
+        let original = std::fs::read(out.join(file)).unwrap();
+        assert_eq!(
+            decompressed, original,
+            "{file}.gz should decompress to {file}"
+        );
+    }
+
+    // Already-compressed assets (images) must not get .gz variants.
+    let image_gz: Vec<_> = walkdir::WalkDir::new(&out)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_lowercase();
+            name.ends_with(".jpg.gz")
+                || name.ends_with(".jpeg.gz")
+                || name.ends_with(".png.gz")
+                || name.ends_with(".webp.gz")
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    assert!(
+        image_gz.is_empty(),
+        "images should not be gzipped: {image_gz:?}"
+    );
+}
+
+#[test]
+fn build_without_compress_writes_no_gzip() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let gz_files: Vec<_> = walkdir::WalkDir::new(&out)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".gz"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    assert!(
+        gz_files.is_empty(),
+        "no .gz files without --compress: {gz_files:?}"
+    );
+}
+
+#[test]
+fn build_compress_twice_does_not_gzip_gzip() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    for _ in 0..2 {
+        Command::cargo_bin("cook")
+            .unwrap()
+            .args([
+                "build",
+                "web",
+                out.to_str().unwrap(),
+                "--base-path",
+                seed.to_str().unwrap(),
+                "--compress",
+            ])
+            .assert()
+            .success();
+    }
+
+    let double_gz: Vec<_> = walkdir::WalkDir::new(&out)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".gz.gz"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    assert!(
+        double_gz.is_empty(),
+        "no double-compressed files: {double_gz:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the optional compression step requested in #345.

`cook build web --compress` walks the generated site and writes a gzip-compressed sibling (`page.html.gz`) next to every text asset — HTML, CSS, JS, JSON, XML, SVG and `.cook` sources — so static hosts that support precompressed assets (notably GitLab Pages) serve them directly. Details:

- **Opt-in** via the flag: hosts like Netlify/CDNs compress on the fly, so the extra files are only written when asked for.
- **gzip only** via `flate2` (level 9), which was already compiled into the binary transitively through `reqwest`/`self_update` — effectively no new dependency. Brotli was considered and left out for now.
- Images/fonts are skipped (already compressed), a `.gz` is only kept when it is actually smaller than the original, and existing `.gz` files are never re-compressed on repeated builds.
- The build summary reports the count: `..., N files compressed`.

Fixes #345

## Testing
Three new integration tests in `tests/build.rs` (written first, confirmed red):
- `--compress` produces `.gz` siblings for `index.html`, the CSS bundle and the search index, which decompress byte-identical to the originals, and no image gets a `.gz`
- default build writes no `.gz` files
- running `--compress` twice produces no `.gz.gz` artifacts

`cargo fmt`, `cargo clippy`, and the full `cargo test` suite pass cleanly.