### PR TITLE
chore(ci): bump Node from 18 to 22 in test and release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
@@ -301,7 +301,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install npm dependencies
@@ -99,7 +99,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install npm dependencies
@@ -165,7 +165,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install npm dependencies
@@ -217,7 +217,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install npm dependencies


### PR DESCRIPTION
Node 18 reached end of life in April 2025, and current Playwright releases refuse to run on it:

```
You are running Node.js 18.20.8.
Playwright requires Node.js 20 or higher.
```

That is what breaks the `UI Tests` job on #402 (the npm dependency group bump), which pulls in a Playwright new enough to enforce the check.

Node 20 is itself EOL as of April 2026, so this goes to 22 (current LTS) rather than the minimum Playwright accepts. Applied to all six pins across `test.yml` and `release.yaml`.

Once this lands, #402 needs a `@dependabot rebase` to pick up the new workflow.