### PR TITLE
ci: let claude-code-review run on Dependabot pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Dependency bumps are exactly the PRs worth a second pair of eyes, but the
+          # action refuses bot actors by default. Named explicitly rather than "*" so
+          # a future App installed on this public repo cannot drive the review prompt.
+          allowed_bots: "dependabot[bot]"
           prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices


### PR DESCRIPTION
`claude-code-review` has never actually reviewed a dependency bump. Every Dependabot PR fails at startup with:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

This allows `dependabot[bot]` by name rather than `*` — cookcli is public, and `*` would let any other installed App invoke the action with a prompt it controls.

## One manual step is still needed

GitHub does not pass **Actions** secrets to Dependabot-triggered runs; they read from a separate **Dependabot** secret store. Right now:

- `CLAUDE_CODE_OAUTH_TOKEN` exists under Actions secrets ✅
- there are **no** Dependabot secrets at all ❌

So until `CLAUDE_CODE_OAUTH_TOKEN` is also added under *Settings → Secrets and variables → Dependabot*, the token resolves to an empty string and the job will still fail — just with an auth error instead of the bot error. It fails today either way, so this is not a regression, but the check only goes green once that secret exists.

Worth knowing: once it works, every dependency bump consumes Claude usage.