### PR TITLE
chore(deps): bump cooklang-import to 0.9.14 and cooklang-sync-client to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "cooklang-import"
-version = "0.9.12"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647cd07650fe59be588a14298684c4278023ceb42c1888d79efe68fa0674e7c8"
+checksum = "80928c4fb43d53eacf1280a8bc6985a2d1b7e5d424d28ac44b610c3027ee7b3a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "cooklang-sync-client"
-version = "0.4.12"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edded9ebd94251c1a9aef56428722934a63d298e310469b7e7514cdb619bfc4"
+checksum = "091a9790342274289a9a9db9a6441488a364323a31312ef040e925a80095e9cc"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ base64 = { version = "0.23", optional = true }
 # depend on cooklang with default features. Declare it where it is actually used.
 cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "bundled_units", "pantry", "shopping_list"] }
 cooklang-find = { version = "0.6.1", default-features = false }
-cooklang-import = { version = "0.9.3", optional = true }
-cooklang-sync-client = { version = "0.4.11", optional = true }
+cooklang-import = { version = "0.9.14", optional = true }
+cooklang-sync-client = { version = "0.5.0", optional = true }
 libsqlite3-sys = { version = "0.35", features = ["bundled"], optional = true }
 cooklang-language-server = { version = "0.2.4", optional = true }
 cooklang-reports = { version = "0.5.1" }


### PR DESCRIPTION
Both pins had drifted behind what is published on crates.io:

| crate | was | now |
|---|---|---|
| cooklang-import | 0.9.3 (resolved 0.9.12) | 0.9.14 |
| cooklang-sync-client | 0.4.11 (resolved 0.4.12) | 0.5.0 |

The sync client's 0.4 → 0.5 bump compiles with no call-site changes — the API cookcli uses is unchanged.

Verified: `cargo test` and `cargo test --no-default-features` (14 suites each), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`.

Note this does **not** deduplicate reqwest — both 0.12 and 0.13 remain in the tree. See the discussion on why unifying is riskier than it looks.