### PR TITLE
feat(server): add a button to copy the shopping list as plain text

### DIFF
--- a/locales/de-DE/shopping.ftl
+++ b/locales/de-DE/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Einkaufsliste konnte nicht erstellt werden
 shopping-failed-to-add = Hinzufügen zur Einkaufsliste fehlgeschlagen
 shopping-error = Fehler
 shopping-print = Drucken
+shopping-copy = Kopieren
+shopping-copied = Kopiert!
+shopping-copy-failed = Kopieren fehlgeschlagen

--- a/locales/en-US/shopping.ftl
+++ b/locales/en-US/shopping.ftl
@@ -27,3 +27,6 @@ shopping-failed-to-add = Failed to add to shopping list
 shopping-error = Error
 shopping-print = Print
 shopping-include-in-list = Include in shopping list
+shopping-copy = Copy
+shopping-copied = Copied!
+shopping-copy-failed = Copy failed

--- a/locales/es-ES/shopping.ftl
+++ b/locales/es-ES/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Error al generar la lista de compras
 shopping-failed-to-add = Error al agregar a la lista de compras
 shopping-error = Error
 shopping-print = Imprimir
+shopping-copy = Copiar
+shopping-copied = ¡Copiado!
+shopping-copy-failed = Error al copiar

--- a/locales/eu-ES/shopping.ftl
+++ b/locales/eu-ES/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Errorea erosketa zerrenda sortzerakoan
 shopping-failed-to-add = Errorea erosketa zerrendara gehitzerakoan
 shopping-error = Errorea
 shopping-print = Inprimatu
+shopping-copy = Kopiatu
+shopping-copied = Kopiatuta!
+shopping-copy-failed = Errorea kopiatzerakoan

--- a/locales/fr-FR/shopping.ftl
+++ b/locales/fr-FR/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Échec de la génération de la liste de courses
 shopping-failed-to-add = Échec de l'ajout à la liste de courses
 shopping-error = Erreur
 shopping-print = Imprimer
+shopping-copy = Copier
+shopping-copied = Copié !
+shopping-copy-failed = Échec de la copie

--- a/locales/nl-NL/shopping.ftl
+++ b/locales/nl-NL/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Boodschappenlijst kon niet worden gegenereerd
 shopping-failed-to-add = Toevoegen aan boodschappenlijst mislukt
 shopping-error = Fout
 shopping-print = Afdrukken
+shopping-copy = Kopiëren
+shopping-copied = Gekopieerd!
+shopping-copy-failed = Kopiëren mislukt

--- a/locales/sv-SE/shopping.ftl
+++ b/locales/sv-SE/shopping.ftl
@@ -26,3 +26,6 @@ shopping-failed-to-generate = Misslyckades att generera handlingslista
 shopping-failed-to-add = Misslyckades att lägga till handlingslista
 shopping-error = Fel
 shopping-print = Skriv ut
+shopping-copy = Kopiera
+shopping-copied = Kopierad!
+shopping-copy-failed = Kopiering misslyckades

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -560,6 +560,9 @@ async function writeToClipboard(text) {
     textarea.style.top = '-1000px';
     document.body.appendChild(textarea);
     textarea.select();
+    // iOS Safari ignores `select()` on a readonly textarea; it needs an
+    // explicit range. Harmless everywhere else.
+    textarea.setSelectionRange(0, text.length);
     try {
         if (!document.execCommand('copy')) {
             throw new Error('execCommand("copy") returned false');

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -11,6 +11,9 @@
             <div id="selected-recipes" class="space-y-2 mb-4">
             </div>
             <div class="space-y-2 mb-6">
+                <button id="copy-list-button" onclick="copyList()" class="hidden w-full px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-all">
+                    {{ tr.t("shopping-copy") }}
+                </button>
                 <button onclick="clearList()" class="w-full px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-all">
                     {{ tr.t("shopping-clear-all") }}
                 </button>
@@ -52,6 +55,10 @@
 
 <script>
 let shoppingList = [];
+
+// Last payload rendered by displayShoppingList(), kept so the copy button can
+// rebuild the list as plain text without re-fetching.
+let lastListData = null;
 
 // Escape a string for safe interpolation into HTML text or a double-quoted
 // attribute value. Recipe names/paths come from filenames — a recipe called
@@ -109,6 +116,8 @@ function renderSelectedRecipes() {
     if (shoppingList.length === 0) {
         container.innerHTML = '<p class="text-gray-500 text-sm">' + escHtml({{ tr.t("shopping-no-recipes")|json|safe }}) + '</p>';
         document.getElementById('list-content').innerHTML = '<p class="text-gray-500">' + escHtml({{ tr.t("shopping-no-items")|json|safe }}) + '</p>';
+        lastListData = null;
+        updateCopyButtonVisibility();
         return;
     }
 
@@ -412,6 +421,9 @@ function displayShoppingList(data) {
     // Populate checked set from server response
     checkedItems = new Set((data.checked || []).map(n => n.toLowerCase()));
 
+    lastListData = data;
+    updateCopyButtonVisibility();
+
     let html = '';
 
     // Display items to buy (organized by aisle)
@@ -504,6 +516,93 @@ function formatQuantities(quantities) {
 // Store for checked items - using ingredient names (lowercased) as keys
 let checkedItems = new Set();
 
+// Render the current list as plain text for pasting into a notes app: a title
+// line, then one block per aisle category — the category name followed by one
+// bare `name qty` line per item. Items already ticked off are left out, and a
+// category that empties out is dropped with them. Returns '' when there is
+// nothing left to buy.
+function buildPlainTextList() {
+    const categories = (lastListData && lastListData.categories) || [];
+    const blocks = [];
+
+    for (const category of categories) {
+        const lines = (category.items || [])
+            .filter(item => !checkedItems.has(String(item.name).toLowerCase()))
+            .map(item => {
+                const quantities = formatQuantities(item.quantities);
+                return quantities ? `${item.name} ${quantities}` : item.name;
+            });
+        if (lines.length > 0) {
+            blocks.push([category.category, ...lines].join('\n'));
+        }
+    }
+
+    if (blocks.length === 0) {
+        return '';
+    }
+    return [{{ tr.t("shopping-title")|json|safe }}, ...blocks].join('\n\n') + '\n';
+}
+
+async function writeToClipboard(text) {
+    // `navigator.clipboard` only exists on secure origins, and the server is
+    // routinely reached over plain http from a phone on the same network —
+    // exactly the case this button is for. Fall back to the legacy path there.
+    if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    // Off-screen rather than hidden: `display: none` elements can't be selected.
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-1000px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+        if (!document.execCommand('copy')) {
+            throw new Error('execCommand("copy") returned false');
+        }
+    } finally {
+        document.body.removeChild(textarea);
+    }
+}
+
+let copyLabelTimer = null;
+
+async function copyList() {
+    const button = document.getElementById('copy-list-button');
+    const text = buildPlainTextList();
+
+    if (!text) {
+        showError({{ tr.t("shopping-no-items")|json|safe }});
+        return;
+    }
+
+    hideError();
+    try {
+        await writeToClipboard(text);
+        button.textContent = {{ tr.t("shopping-copied")|json|safe }};
+    } catch (error) {
+        console.error('Failed to copy shopping list:', error);
+        button.textContent = {{ tr.t("shopping-copy-failed")|json|safe }};
+    }
+
+    clearTimeout(copyLabelTimer);
+    copyLabelTimer = setTimeout(() => {
+        button.textContent = {{ tr.t("shopping-copy")|json|safe }};
+    }, 1500);
+}
+
+// Hide the button whenever there is nothing to copy — an empty list, or every
+// item already ticked off.
+function updateCopyButtonVisibility() {
+    const button = document.getElementById('copy-list-button');
+    if (!button) return;
+    button.classList.toggle('hidden', buildPlainTextList() === '');
+}
+
 async function toggleItem(itemId, checked, ingredientName) {
     const storageKey = ingredientName || itemId;
     const endpoint = checked ? 'check' : 'uncheck';
@@ -531,6 +630,7 @@ async function toggleItem(itemId, checked, ingredientName) {
     }
 
     applyCheckedStyle(itemId, checked);
+    updateCopyButtonVisibility();
 }
 
 function applyCheckedStyle(itemId, checked) {

--- a/tests/e2e/shopping-list-copy.spec.ts
+++ b/tests/e2e/shopping-list-copy.spec.ts
@@ -63,14 +63,20 @@ test.describe('Copy shopping list to clipboard', () => {
 
     // Easy Pancakes contributes eggs, flour, milk, sea salt and butter. Each
     // is a bare line — no bullet, no checkbox — under its aisle heading.
-    expect(text).toMatch(/^eggs 3$/m);
+    //
+    // Names are the aisle's *common* names, not the ones written in the .cook
+    // file: aisle.conf maps `egg | eggs` and `salt | sea salt`, and the copy
+    // reuses the same aggregated payload the page renders from.
+    expect(text).toMatch(/^egg 3$/m);
     expect(text).toMatch(/^flour 125 g$/m);
     expect(text).toMatch(/^milk 250 ml$/m);
+    // Two quantities of the same ingredient stay on one line.
+    expect(text).toMatch(/^salt 1 tbsp, pinch$/m);
 
     // Aisle headings are present and are not themselves item lines.
     const headings = lines.filter((line, i) => line !== '' && lines[i - 1] === '' && i > 1);
-    expect(headings.length).toBeGreaterThan(0);
-    expect(headings).not.toContain('eggs 3');
+    expect(headings).toContain('milk and dairy');
+    expect(headings).not.toContain('egg 3');
   });
 
   test('leaves out items that are already ticked off', async ({ page }) => {
@@ -80,16 +86,28 @@ test.describe('Copy shopping list to clipboard', () => {
     const helpers = new TestHelpers(page);
     await helpers.goToShoppingList();
 
-    const eggs = page.locator('input[data-ingredient-name="eggs"]');
-    await expect(eggs).toBeVisible({ timeout: 10_000 });
-    await eggs.check();
-
     const copyButton = page.locator('#copy-list-button');
+    await expect(copyButton).toBeVisible({ timeout: 10_000 });
+
+    // Establish that the item IS in the copy before ticking it off — otherwise
+    // the negative assertion below would also pass if the name were simply
+    // wrong (which is how an earlier revision of this test fooled itself).
+    await copyButton.click();
+    await expect(copyButton).toHaveText(/copied/i);
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toMatch(/^egg 3$/m);
+
+    // `egg` is the aisle common name for the recipe's `eggs`; the checkbox is
+    // keyed on the displayed name.
+    const egg = page.locator('input[data-ingredient-name="egg"]');
+    await expect(egg).toBeVisible();
+    await egg.check();
+
+    await expect(copyButton).toHaveText(/^copy$/i);
     await copyButton.click();
     await expect(copyButton).toHaveText(/copied/i);
 
     const text = await page.evaluate(() => navigator.clipboard.readText());
-    expect(text).not.toMatch(/^eggs 3$/m);
+    expect(text).not.toMatch(/^egg 3$/m);
     // Unchecked items are untouched.
     expect(text).toMatch(/^flour 125 g$/m);
   });

--- a/tests/e2e/shopping-list-copy.spec.ts
+++ b/tests/e2e/shopping-list-copy.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { TestHelpers } from '../fixtures/test-helpers';
+
+// Seed directory used by the dev server started by Playwright's `webServer`.
+// Kept in sync with `playwright.config.ts`'s `cwd`/command.
+const SEED_DIR = path.resolve(__dirname, '../../seed');
+const LIST_FILE = path.join(SEED_DIR, '.shopping-list');
+const CHECKED_FILE = path.join(SEED_DIR, '.shopping-checked');
+
+function backup(file: string): string | null {
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null;
+}
+
+function restore(file: string, content: string | null | undefined) {
+  // `undefined` means beforeEach never got as far as taking a backup (e.g. the
+  // browser failed to launch) — leave the file alone rather than deleting it.
+  if (content === undefined) return;
+  if (content === null) {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  } else {
+    fs.writeFileSync(file, content);
+  }
+}
+
+test.describe('Copy shopping list to clipboard', () => {
+  let originalList: string | null | undefined;
+  let originalChecked: string | null | undefined;
+
+  test.beforeEach(async ({ context }) => {
+    originalList = backup(LIST_FILE);
+    originalChecked = backup(CHECKED_FILE);
+    // baseURL is http://localhost, which counts as a secure context, so the
+    // async clipboard API is the path exercised here.
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  });
+
+  test.afterEach(async () => {
+    restore(LIST_FILE, originalList);
+    restore(CHECKED_FILE, originalChecked);
+  });
+
+  test('copies the list grouped by aisle, one item per line', async ({ page }) => {
+    // Recipe paths in the .shopping-list format require a "./" prefix.
+    fs.writeFileSync(LIST_FILE, './Breakfast/Easy Pancakes\n');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    const copyButton = page.locator('#copy-list-button');
+    await expect(copyButton).toBeVisible({ timeout: 10_000 });
+    await copyButton.click();
+    await expect(copyButton).toHaveText(/copied/i);
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    const lines = text.split('\n');
+
+    // Title, blank line, then the first aisle group.
+    expect(lines[0]).toBe('Shopping List');
+    expect(lines[1]).toBe('');
+
+    // Easy Pancakes contributes eggs, flour, milk, sea salt and butter. Each
+    // is a bare line — no bullet, no checkbox — under its aisle heading.
+    expect(text).toMatch(/^eggs 3$/m);
+    expect(text).toMatch(/^flour 125 g$/m);
+    expect(text).toMatch(/^milk 250 ml$/m);
+
+    // Aisle headings are present and are not themselves item lines.
+    const headings = lines.filter((line, i) => line !== '' && lines[i - 1] === '' && i > 1);
+    expect(headings.length).toBeGreaterThan(0);
+    expect(headings).not.toContain('eggs 3');
+  });
+
+  test('leaves out items that are already ticked off', async ({ page }) => {
+    fs.writeFileSync(LIST_FILE, './Breakfast/Easy Pancakes\n');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    const eggs = page.locator('input[data-ingredient-name="eggs"]');
+    await expect(eggs).toBeVisible({ timeout: 10_000 });
+    await eggs.check();
+
+    const copyButton = page.locator('#copy-list-button');
+    await copyButton.click();
+    await expect(copyButton).toHaveText(/copied/i);
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    expect(text).not.toMatch(/^eggs 3$/m);
+    // Unchecked items are untouched.
+    expect(text).toMatch(/^flour 125 g$/m);
+  });
+
+  test('hides the copy button when there is nothing to buy', async ({ page }) => {
+    fs.writeFileSync(LIST_FILE, '');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    await expect(page.locator('#selected-recipes').getByText(/no recipes/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator('#copy-list-button')).toBeHidden();
+  });
+});


### PR DESCRIPTION
Addresses point 2 of #380 — a plaintext, non-HTML view of the shopping list for pasting into other tools.

Points 1 and 3 of that issue (exporting the list as a `.menu` file, importing one) were split off to #385 per the discussion in the thread, so this PR is scoped to the copy button only.

## What it does

Adds a **Copy** button to the shopping list sidebar. It puts the current list on the clipboard as plain text, grouped by aisle category — the category name on its own line, then one bare `name qty` line per item, with a blank line between groups:

```
Shopping List

milk and dairy
milk 250 ml
butter knob
egg 3

tinned goods and baking
flour 125 g

dried herbs and spices
salt 1 tbsp, pinch
```

That shape is what @daviddehoog asked for in the thread — "group name from aisle.conf or item and then a new line" — so it pastes cleanly into a notes app without needing a parser on the other end.

Items already ticked off are left out, and a category that empties out is dropped with them: the copy is what's still to buy. The button hides itself when there is nothing left.

Names come out as the aisle's common names (`egg`, not `eggs`), matching what the page already displays, because it reuses the same aggregated payload the UI renders from.

## Notes

- **Client-side only.** No new endpoints; `displayShoppingList()` already receives everything needed, so the payload is just stashed for the button to re-render as text.
- **`execCommand` fallback.** `navigator.clipboard` only exists on secure origins, but `cook server` is routinely reached over plain http from a phone on the LAN — exactly the case this button is for. A hidden-textarea + `document.execCommand('copy')` path covers that.
- New locale keys `shopping-copy` / `shopping-copied` / `shopping-copy-failed` are translated in all seven locales.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets` and `cargo test` all pass.

Verified by hand in Chrome against `cook server ./seed`: clicked the button, pasted the system clipboard back into the page, and got exactly the output above. Ticking `egg` dropped `egg 3` from the next copy; ticking everything hid the button.

⚠️ The three added Playwright cases in `tests/e2e/shopping-list-copy.spec.ts` have **not been executed** — Playwright refuses to install its browser on the macOS version I'm on, so CI will be the first real run. The behavior they assert is verified by hand as above, but the spec's own selectors and timing are not.

Refs #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)