### PR TITLE
feat(server): add copy options to the shopping list copy button

### DIFF
--- a/locales/de-DE/shopping.ftl
+++ b/locales/de-DE/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Drucken
 shopping-copy = Kopieren
 shopping-copied = Kopiert!
 shopping-copy-failed = Kopieren fehlgeschlagen
+shopping-copy-options = Kopieroptionen
+shopping-copy-include-aisles = Regalnamen einschließen
+shopping-copy-include-amounts = Mengen einschließen

--- a/locales/en-US/shopping.ftl
+++ b/locales/en-US/shopping.ftl
@@ -30,3 +30,6 @@ shopping-include-in-list = Include in shopping list
 shopping-copy = Copy
 shopping-copied = Copied!
 shopping-copy-failed = Copy failed
+shopping-copy-options = Copy options
+shopping-copy-include-aisles = Include aisle names
+shopping-copy-include-amounts = Include amounts

--- a/locales/es-ES/shopping.ftl
+++ b/locales/es-ES/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Imprimir
 shopping-copy = Copiar
 shopping-copied = ¡Copiado!
 shopping-copy-failed = Error al copiar
+shopping-copy-options = Opciones de copia
+shopping-copy-include-aisles = Incluir nombres de secciones
+shopping-copy-include-amounts = Incluir cantidades

--- a/locales/eu-ES/shopping.ftl
+++ b/locales/eu-ES/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Inprimatu
 shopping-copy = Kopiatu
 shopping-copied = Kopiatuta!
 shopping-copy-failed = Errorea kopiatzerakoan
+shopping-copy-options = Kopiatzeko aukerak
+shopping-copy-include-aisles = Sailen izenak sartu
+shopping-copy-include-amounts = Kopuruak sartu

--- a/locales/fr-FR/shopping.ftl
+++ b/locales/fr-FR/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Imprimer
 shopping-copy = Copier
 shopping-copied = Copié !
 shopping-copy-failed = Échec de la copie
+shopping-copy-options = Options de copie
+shopping-copy-include-aisles = Inclure les noms de rayons
+shopping-copy-include-amounts = Inclure les quantités

--- a/locales/nl-NL/shopping.ftl
+++ b/locales/nl-NL/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Afdrukken
 shopping-copy = Kopiëren
 shopping-copied = Gekopieerd!
 shopping-copy-failed = Kopiëren mislukt
+shopping-copy-options = Kopieeropties
+shopping-copy-include-aisles = Schapnamen opnemen
+shopping-copy-include-amounts = Hoeveelheden opnemen

--- a/locales/sv-SE/shopping.ftl
+++ b/locales/sv-SE/shopping.ftl
@@ -29,3 +29,6 @@ shopping-print = Skriv ut
 shopping-copy = Kopiera
 shopping-copied = Kopierad!
 shopping-copy-failed = Kopiering misslyckades
+shopping-copy-options = Kopieringsalternativ
+shopping-copy-include-aisles = Inkludera hyllnamn
+shopping-copy-include-amounts = Inkludera mängder

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,15 +78,19 @@
             border-color: #7c3aed;
         }
 
-        .dark .hover\\:text-gray-900:hover {
+        .dark .hover\:text-gray-900:hover {
             color: #f9fafb;
         }
 
-        .dark .hover\\:text-gray-800:hover {
+        .dark .hover\:text-gray-800:hover {
             color: #e5e7eb;
         }
 
-        .dark .hover\\:bg-gray-100:hover {
+        .dark .hover\:bg-gray-50:hover {
+            background-color: #374151;
+        }
+
+        .dark .hover\:bg-gray-100:hover {
             background-color: #374151;
         }
 
@@ -148,41 +152,41 @@
         }
 
         /* Dark mode hover states */
-        .dark .hover\\:bg-gradient-to-r:hover {
+        .dark .hover\:bg-gradient-to-r:hover {
             background: #374151 !important;
         }
 
-        .dark .hover\\:from-purple-50:hover,
-        .dark .hover\\:to-pink-50:hover {
+        .dark .hover\:from-purple-50:hover,
+        .dark .hover\:to-pink-50:hover {
             background: #374151 !important;
         }
 
-        .dark .hover\\:from-orange-100:hover,
-        .dark .hover\\:to-amber-100:hover {
+        .dark .hover\:from-orange-100:hover,
+        .dark .hover\:to-amber-100:hover {
             background: #374151 !important;
         }
 
-        .dark .hover\\:from-purple-100:hover,
-        .dark .hover\\:to-pink-100:hover {
+        .dark .hover\:from-purple-100:hover,
+        .dark .hover\:to-pink-100:hover {
             background: #374151 !important;
         }
 
-        .dark a.hover\\:bg-gradient-to-r:hover {
+        .dark a.hover\:bg-gradient-to-r:hover {
             background: #374151 !important;
             color: #e5e7eb !important;
         }
 
         /* Fix for navigation pill hover states */
-        .dark a[href="{{ prefix }}/"].hover\\:bg-gradient-to-r:hover{% if !static_mode %},
-        .dark a[href="{{ prefix }}/shopping-list"].hover\\:bg-gradient-to-r:hover{% endif %} {
+        .dark a[href="{{ prefix }}/"].hover\:bg-gradient-to-r:hover{% if !static_mode %},
+        .dark a[href="{{ prefix }}/shopping-list"].hover\:bg-gradient-to-r:hover{% endif %} {
             background: #374151 !important;
         }
 
-        .dark .hover\\:text-orange-700:hover {
+        .dark .hover\:text-orange-700:hover {
             color: #fb923c !important;
         }
 
-        .dark .hover\\:text-purple-700:hover {
+        .dark .hover\:text-purple-700:hover {
             color: #a78bfa !important;
         }
 
@@ -206,7 +210,7 @@
             background-color: #4b5563;
         }
 
-        .dark .hover\\:bg-gray-300:hover {
+        .dark .hover\:bg-gray-300:hover {
             background-color: #6b7280;
         }
 
@@ -223,7 +227,7 @@
             color: #ef4444;
         }
 
-        .dark .hover\\:text-red-700:hover {
+        .dark .hover\:text-red-700:hover {
             color: #dc2626;
         }
 
@@ -295,7 +299,7 @@
         }
 
         /* Override inline hover styles in search results */
-        .dark #search-results a.hover\\:bg-gradient-to-r:hover {
+        .dark #search-results a.hover\:bg-gradient-to-r:hover {
             background: #374151 !important;
         }
 
@@ -474,7 +478,7 @@
             }
 
             /* Hide navigation and non-essential elements */
-            nav, #search-container, #search-input, #search-results, .print\\:hidden, .breadcrumb {
+            nav, #search-container, #search-input, #search-results, .print\:hidden, .breadcrumb {
                 display: none !important;
             }
 
@@ -517,7 +521,7 @@
             }
 
             /* Page breaks */
-            .md\\:col-span-1, .md\\:col-span-2 {
+            .md\:col-span-1, .md\:col-span-2 {
                 page-break-inside: avoid;
                 width: 100% !important;
             }
@@ -577,19 +581,19 @@
             }
 
             /* Print-specific flexbox utilities */
-            .print\\:flex-row {
+            .print\:flex-row {
                 flex-direction: row !important;
             }
 
-            .print\\:items-center {
+            .print\:items-center {
                 align-items: center !important;
             }
 
-            .print\\:block {
+            .print\:block {
                 display: block !important;
             }
 
-            .print\\:text-2xl {
+            .print\:text-2xl {
                 font-size: 1.5rem !important;
             }
 

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -8,15 +8,7 @@
     <div class="lg:w-2/5 xl:w-1/3">
         <div class="bg-white rounded-2xl shadow-lg p-6 sticky top-6">
             <h3 class="font-bold text-lg mb-3 text-orange-600">{{ tr.t("shopping-selected-recipes") }}</h3>
-            <div id="selected-recipes" class="space-y-2 mb-4">
-            </div>
-            <div class="space-y-2 mb-6">
-                <button id="copy-list-button" onclick="copyList()" class="hidden w-full px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-all">
-                    {{ tr.t("shopping-copy") }}
-                </button>
-                <button onclick="clearList()" class="w-full px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-all">
-                    {{ tr.t("shopping-clear-all") }}
-                </button>
+            <div id="selected-recipes" class="space-y-2 mb-6">
             </div>
 
             <!-- Pantry items section -->
@@ -44,6 +36,46 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                     </svg>
+                </button>
+            </div>
+        </div>
+        <!-- Heading and list actions share a row; the heading lives here rather
+             than in the JS-rendered list so the buttons stay put while the list
+             below them re-renders. -->
+        <div id="shopping-list-header" class="hidden flex-wrap items-center justify-between gap-3 mb-4">
+            <h2 class="text-2xl font-bold text-orange-700">{{ tr.t("shopping-title") }}</h2>
+            <div class="flex items-center gap-2">
+                <!-- Split button: the left half copies, the right half opens the
+                     checkboxes that decide what the copied text contains. -->
+                <div id="copy-list-group" class="hidden relative">
+                    <div class="flex">
+                        <button id="copy-list-button" onclick="copyList()" class="px-4 py-2 bg-orange-600 text-white rounded-l-lg hover:bg-orange-700 transition-all">
+                            {{ tr.t("shopping-copy") }}
+                        </button>
+                        <button id="copy-options-toggle" type="button" onclick="toggleCopyOptions()"
+                            aria-haspopup="true" aria-expanded="false" aria-controls="copy-options-menu"
+                            aria-label="{{ tr.t("shopping-copy-options") }}"
+                            class="px-3 py-2 bg-orange-600 text-white rounded-r-lg border-l border-orange-500 hover:bg-orange-700 transition-all">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div id="copy-options-menu" class="hidden absolute right-0 mt-2 w-64 bg-white border border-gray-200 rounded-xl shadow-xl z-50 py-1">
+                        <label class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">
+                            <input type="checkbox" id="copy-option-aisles" onchange="onCopyOptionChange()"
+                                class="w-4 h-4 text-orange-600 rounded-sm focus:ring-orange-500">
+                            <span>{{ tr.t("shopping-copy-include-aisles") }}</span>
+                        </label>
+                        <label class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer">
+                            <input type="checkbox" id="copy-option-amounts" onchange="onCopyOptionChange()"
+                                class="w-4 h-4 text-orange-600 rounded-sm focus:ring-orange-500">
+                            <span>{{ tr.t("shopping-copy-include-amounts") }}</span>
+                        </label>
+                    </div>
+                </div>
+                <button onclick="clearList()" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-all">
+                    {{ tr.t("shopping-clear-all") }}
                 </button>
             </div>
         </div>
@@ -112,6 +144,12 @@ async function loadShoppingList() {
 
 function renderSelectedRecipes() {
     const container = document.getElementById('selected-recipes');
+
+    // The heading and its buttons live in the same row, so the row follows the
+    // selection rather than the generated items: with recipes selected but
+    // every ingredient in the pantry there is nothing to copy, yet Clear All
+    // still has to be reachable.
+    setHeaderVisible(shoppingList.length > 0);
 
     if (shoppingList.length === 0) {
         container.innerHTML = '<p class="text-gray-500 text-sm">' + escHtml({{ tr.t("shopping-no-recipes")|json|safe }}) + '</p>';
@@ -428,7 +466,6 @@ function displayShoppingList(data) {
 
     // Display items to buy (organized by aisle)
     if (data.categories && data.categories.length > 0) {
-        html += '<h2 class="text-2xl font-bold mb-4 text-orange-700">' + escHtml({{ tr.t("shopping-title")|json|safe }}) + '</h2>';
         html += data.categories.map(category => `
             <div class="mb-6 bg-white rounded-lg p-4 shadow-xs">
                 <h3 class="font-semibold text-lg mb-3 text-orange-600">${escHtml(category.category)}</h3>
@@ -516,11 +553,67 @@ function formatQuantities(quantities) {
 // Store for checked items - using ingredient names (lowercased) as keys
 let checkedItems = new Set();
 
-// Render the current list as plain text for pasting into a notes app: a title
-// line, then one block per aisle category — the category name followed by one
-// bare `name qty` line per item. Items already ticked off are left out, and a
-// category that empties out is dropped with them. Returns '' when there is
-// nothing left to buy.
+// What the copy button puts on the clipboard. Persisted so the choice survives
+// a reload — this is a per-device preference, not list state, so it stays in
+// localStorage rather than on the server.
+const COPY_OPTIONS_KEY = 'shopping-copy-options';
+let copyOptions = { aisles: true, amounts: true };
+
+function loadCopyOptions() {
+    try {
+        const stored = JSON.parse(localStorage.getItem(COPY_OPTIONS_KEY));
+        if (stored && typeof stored === 'object') {
+            // Anything that isn't an explicit `false` keeps the default — a
+            // half-written or older payload degrades to "include everything".
+            copyOptions = {
+                aisles: stored.aisles !== false,
+                amounts: stored.amounts !== false,
+            };
+        }
+    } catch (error) {
+        // Malformed JSON, or localStorage blocked entirely (Safari private
+        // browsing). Defaults are fine.
+        console.error('Failed to read copy options:', error);
+    }
+
+    document.getElementById('copy-option-aisles').checked = copyOptions.aisles;
+    document.getElementById('copy-option-amounts').checked = copyOptions.amounts;
+}
+
+function onCopyOptionChange() {
+    copyOptions = {
+        aisles: document.getElementById('copy-option-aisles').checked,
+        amounts: document.getElementById('copy-option-amounts').checked,
+    };
+    try {
+        localStorage.setItem(COPY_OPTIONS_KEY, JSON.stringify(copyOptions));
+    } catch (error) {
+        console.error('Failed to save copy options:', error);
+    }
+}
+
+function toggleCopyOptions() {
+    const menu = document.getElementById('copy-options-menu');
+    const open = menu.classList.toggle('hidden') === false;
+    document.getElementById('copy-options-toggle').setAttribute('aria-expanded', String(open));
+}
+
+function closeCopyOptions() {
+    document.getElementById('copy-options-menu').classList.add('hidden');
+    document.getElementById('copy-options-toggle').setAttribute('aria-expanded', 'false');
+}
+
+document.addEventListener('click', (event) => {
+    if (!event.target.closest('#copy-list-group')) {
+        closeCopyOptions();
+    }
+});
+
+// Render the current list as plain text for pasting into a notes app: one block
+// per aisle category — the category name followed by one bare `name qty` line
+// per item — or a single flat block when aisle names are switched off. Items
+// already ticked off are left out, and a category that empties out is dropped
+// with them. Returns '' when there is nothing left to buy.
 function buildPlainTextList() {
     const categories = (lastListData && lastListData.categories) || [];
     const blocks = [];
@@ -529,18 +622,20 @@ function buildPlainTextList() {
         const lines = (category.items || [])
             .filter(item => !checkedItems.has(String(item.name).toLowerCase()))
             .map(item => {
-                const quantities = formatQuantities(item.quantities);
+                const quantities = copyOptions.amounts ? formatQuantities(item.quantities) : '';
                 return quantities ? `${item.name} ${quantities}` : item.name;
             });
         if (lines.length > 0) {
-            blocks.push([category.category, ...lines].join('\n'));
+            blocks.push(copyOptions.aisles ? [category.category, ...lines].join('\n') : lines.join('\n'));
         }
     }
 
     if (blocks.length === 0) {
         return '';
     }
-    return [{{ tr.t("shopping-title")|json|safe }}, ...blocks].join('\n\n') + '\n';
+    // Blank lines separate aisle blocks; without headings there is nothing to
+    // separate, so the categories run together as one list.
+    return blocks.join(copyOptions.aisles ? '\n\n' : '\n') + '\n';
 }
 
 async function writeToClipboard(text) {
@@ -598,12 +693,28 @@ async function copyList() {
     }, 1500);
 }
 
+// `hidden` and `flex` are both display utilities, so the row has to swap
+// between them rather than just dropping `hidden`.
+function setHeaderVisible(visible) {
+    const header = document.getElementById('shopping-list-header');
+    if (!header) return;
+    header.classList.toggle('hidden', !visible);
+    header.classList.toggle('flex', visible);
+    if (!visible) {
+        closeCopyOptions();
+    }
+}
+
 // Hide the button whenever there is nothing to copy — an empty list, or every
 // item already ticked off.
 function updateCopyButtonVisibility() {
-    const button = document.getElementById('copy-list-button');
-    if (!button) return;
-    button.classList.toggle('hidden', buildPlainTextList() === '');
+    const group = document.getElementById('copy-list-group');
+    if (!group) return;
+    const empty = buildPlainTextList() === '';
+    group.classList.toggle('hidden', empty);
+    if (empty) {
+        closeCopyOptions();
+    }
 }
 
 async function toggleItem(itemId, checked, ingredientName) {
@@ -661,6 +772,7 @@ function loadCheckedStates() {
     });
 }
 
+loadCopyOptions();
 loadShoppingList();
 
 // Subscribe to server-pushed change events so sync pulls, other-tab edits,

--- a/tests/e2e/shopping-list-copy.spec.ts
+++ b/tests/e2e/shopping-list-copy.spec.ts
@@ -57,10 +57,6 @@ test.describe('Copy shopping list to clipboard', () => {
     const text = await page.evaluate(() => navigator.clipboard.readText());
     const lines = text.split('\n');
 
-    // Title, blank line, then the first aisle group.
-    expect(lines[0]).toBe('Shopping List');
-    expect(lines[1]).toBe('');
-
     // Easy Pancakes contributes eggs, flour, milk, sea salt and butter. Each
     // is a bare line — no bullet, no checkbox — under its aisle heading.
     //
@@ -73,10 +69,14 @@ test.describe('Copy shopping list to clipboard', () => {
     // Two quantities of the same ingredient stay on one line.
     expect(text).toMatch(/^salt 1 tbsp, pinch$/m);
 
-    // Aisle headings are present and are not themselves item lines.
-    const headings = lines.filter((line, i) => line !== '' && lines[i - 1] === '' && i > 1);
+    // Aisle headings are present and are not themselves item lines. A heading
+    // opens the text or follows the blank line that closes the previous group.
+    const headings = lines.filter((line, i) => line !== '' && (i === 0 || lines[i - 1] === ''));
     expect(headings).toContain('milk and dairy');
     expect(headings).not.toContain('egg 3');
+
+    // The list is what it starts with — no title line to delete after pasting.
+    expect(lines[0]).not.toMatch(/shopping list/i);
   });
 
   test('leaves out items that are already ticked off', async ({ page }) => {
@@ -110,6 +110,76 @@ test.describe('Copy shopping list to clipboard', () => {
     expect(text).not.toMatch(/^egg 3$/m);
     // Unchecked items are untouched.
     expect(text).toMatch(/^flour 125 g$/m);
+  });
+
+  test('drops the amounts when the amounts option is off', async ({ page }) => {
+    fs.writeFileSync(LIST_FILE, './Breakfast/Easy Pancakes\n');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    const copyButton = page.locator('#copy-list-button');
+    await expect(copyButton).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('#copy-options-toggle').click();
+    await page.locator('#copy-option-amounts').uncheck();
+    await copyButton.click();
+    await expect(copyButton).toHaveText(/copied/i);
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    // Bare names, and no trailing space where the quantity used to sit.
+    expect(text).toMatch(/^egg$/m);
+    expect(text).toMatch(/^flour$/m);
+    expect(text).not.toMatch(/125 g/);
+    // Aisle headings are a separate option and stay put.
+    expect(text).toMatch(/^milk and dairy$/m);
+  });
+
+  test('drops the aisle headings when the aisle option is off', async ({ page }) => {
+    fs.writeFileSync(LIST_FILE, './Breakfast/Easy Pancakes\n');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    const copyButton = page.locator('#copy-list-button');
+    await expect(copyButton).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('#copy-options-toggle').click();
+    await page.locator('#copy-option-aisles').uncheck();
+    await copyButton.click();
+    await expect(copyButton).toHaveText(/copied/i);
+
+    const text = await page.evaluate(() => navigator.clipboard.readText());
+    expect(text).not.toMatch(/^milk and dairy$/m);
+    // Items keep their amounts, and run together as one block: with no headings
+    // left there is nothing for a blank line to separate.
+    expect(text).toMatch(/^flour 125 g$/m);
+    expect(text.trimEnd()).not.toContain('\n\n');
+  });
+
+  test('remembers the copy options across a reload', async ({ page }) => {
+    fs.writeFileSync(LIST_FILE, './Breakfast/Easy Pancakes\n');
+    fs.writeFileSync(CHECKED_FILE, '');
+
+    const helpers = new TestHelpers(page);
+    await helpers.goToShoppingList();
+
+    await expect(page.locator('#copy-list-button')).toBeVisible({ timeout: 10_000 });
+
+    // Both options default on for a browser that has never set them.
+    await page.locator('#copy-options-toggle').click();
+    await expect(page.locator('#copy-option-aisles')).toBeChecked();
+    await expect(page.locator('#copy-option-amounts')).toBeChecked();
+
+    await page.locator('#copy-option-amounts').uncheck();
+
+    await helpers.goToShoppingList();
+    await expect(page.locator('#copy-list-button')).toBeVisible({ timeout: 10_000 });
+    await page.locator('#copy-options-toggle').click();
+    await expect(page.locator('#copy-option-amounts')).not.toBeChecked();
+    await expect(page.locator('#copy-option-aisles')).toBeChecked();
   });
 
   test('hides the copy button when there is nothing to buy', async ({ page }) => {


### PR DESCRIPTION
## Summary

The shopping list's copied text started with a `Shopping List` title line that had to be deleted by hand after every paste. This drops it and adds a dropdown for configuring what else the copy includes.

**Copy is now a split button.** The chevron opens two checkboxes — *Include aisle names* and *Include amounts* — persisted in `localStorage` under `shopping-copy-options`. Both default on, so first-run output matches today's minus the title. With aisle names off the categories collapse into one flat list, since there are no headings left to separate.

```
fruit and veg              garlic 4 cloves
garlic 4 cloves            milk 11.567 c
                    →      butter 2 tbsp, knob
milk and dairy             egg 30
milk 11.567 c
butter 2 tbsp, knob
```

**Both buttons moved beside the heading.** Copy and Clear All left the sidebar for a row next to "Shopping List". The heading moved out of the JS-rendered list so the buttons stay put while the list re-renders below. The row follows the recipe selection rather than the generated items — with recipes selected but every ingredient in the pantry there is nothing to copy, yet Clear All still has to be reachable.

Three new Fluent keys, translated across all seven locales.

## Drive-by fix: dead CSS in `base.html`

Every `.hover\\:...` selector in the base stylesheet was dead. In CSS `\\:` is an escaped *backslash*, so `.hover\\:bg-gray-100` matched a class literally named `hover\:bg-gray-100` rather than Tailwind's `hover:bg-gray-100`. Confirmed in the browser: the rules matched zero elements, against nine carrying the class.

The visible symptom was dark mode — list rows flashed a near-white background on hover because none of the `.dark .hover\:*` overrides applied. Fixed 18 selectors and added the missing `.dark .hover\:bg-gray-50:hover` rule, which is the class the shopping list rows actually use.

The six print-media selectors carried the same typo. Five duplicate utilities Tailwind already emits correctly, so they only gain `!important` — no visible change. One was genuinely dead:

```css
.md\:col-span-1, .md\:col-span-2 { break-inside: avoid; width: 100% !important; }
```

Printing a recipe now collapses the `md:grid-cols-3` layout to full-width stacked blocks that avoid page breaks, as the block's "Page breaks" comment intended.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` pass clean.

Manually verified in Chrome against `cook server ./seed`, in both light and dark themes:

- all four checkbox combinations produce the expected text, with ticked-off items excluded
- options survive a reload; outside-click closes the menu; `aria-expanded` tracks state
- Clear All hides the whole row; recipes-selected-but-no-items keeps Clear All reachable
- dark row hover is now a subtle gray instead of near-white

Two caveats on verification:

- The copy flow was confirmed by stubbing `writeToClipboard` to capture its exact input — the real `navigator.clipboard` call hangs under browser automation when the tab lacks focus. That code path is untouched, but no real system-clipboard write was observed.
- The print selectors were verified via the DOM (rules parse, sit inside `@media print`, and their target elements exist). The harness has no print-media emulation, so the new single-column print layout was not visually rendered.
