### PR TITLE
Fix: Add server feature for docker image to address #421

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN npm run build-css && npm run build-js
 # Build Rust binary without self-update feature
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/cookcli/target \
-    cargo build --release --no-default-features \
+    cargo build --release --no-default-features --features server \
     && cp target/release/cook /usr/local/bin/cook
 
 # --- Runtime stage ---


### PR DESCRIPTION
Fixes #421.
## The Issue
#369 broke the docker image as it was still assuming server feature was enabled when `--no-default-features` is set.
Added `--features server` to the cargo build which has fixed this.

## Testing
I have run a docker build on the amended Dockerfile and the output of `cook help` now includes the server command and `cook server` now starts the http server.