### PR TITLE
fix(ci): build Linux glibc binary against an older glibc

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,15 @@
+# The glibc target must NOT use the `edge` image. `edge` tracks cross's main
+# branch, which is currently Ubuntu 24.04 / glibc 2.39, so the binary ends up
+# requiring GLIBC_2.38 (`__isoc23_strtol`/`__isoc23_sscanf`, emitted by gcc 13)
+# and GLIBC_2.39 (`pidfd_spawnp`/`pidfd_getpid`, from std's process spawning).
+# That broke every distro older than Ubuntu 24.04, including Debian 12, which
+# is supported until 2028 and ships glibc 2.36 (issue #420).
+#
+# The released 0.2.5 image is Ubuntu 16.04 / glibc 2.23, which keeps the floor
+# at GLIBC_2.18. The musl targets below are statically linked, so `edge` is
+# harmless there.
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
 [target.x86_64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:edge"


### PR DESCRIPTION
Fixes #420.

## The bug

`Cross.toml` pinned the `x86_64-unknown-linux-gnu` target to the cross `edge` image. `edge` tracks cross's `main` branch, which is now **Ubuntu 24.04 / glibc 2.39**, so the released binary picked up four symbols no older distro provides:

| symbol | version | source |
| --- | --- | --- |
| `__isoc23_strtol`, `__isoc23_sscanf` | 2.38 | C deps (SQLite, aws-lc, ring) compiled by gcc 13 |
| `pidfd_spawnp`, `pidfd_getpid` | 2.39 | Rust std process spawning |

Debian 12 ships glibc 2.36 and is supported until 2028, so `cook` stopped starting there entirely:

```
cook: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by cook)
cook: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by cook)
```

The `edge` pin came from bc6f054 (Sep 2025) as a blanket change across all targets. It's harmless for the musl targets — they're statically linked — but for glibc it silently raised the runtime floor to Ubuntu 24.04, and only bit users once the upstream image drifted. This was never a deliberate decision to drop older distros.

## The fix

Pin that one target to the released `0.2.5` image (Ubuntu 16.04 / glibc 2.23) and add a comment explaining why it must not follow `edge`. musl and freebsd are left on `edge`.

## Verification

Ran the real `cross build --release --locked --target x86_64-unknown-linux-gnu` against the `0.2.5` image locally on an Intel host (clean target dir, 11m49s). Despite the image's gcc 5.4, `aws-lc-sys`, `libsqlite3-sys` and `ring` all compile fine.

The binary's glibc floor drops from **2.39 to 2.18**. Smoke-tested `cook --version` in containers:

| distro | glibc | result |
| --- | --- | --- |
| `debian:12` | 2.36 | ok — the reported failure |
| `debian:11` | 2.31 | ok |
| `ubuntu:20.04` | 2.31 | ok |
| `ubuntu:22.04` | 2.35 | ok |
| `rockylinux:9` | 2.34 | ok |

For contrast, the shipped v0.33.0 asset reproduces the report exactly on `debian:12`.

`cargo fmt --check`, `cargo clippy --all-targets` and `cargo test` all pass clean.

## Notes

- This only takes effect on the next release; v0.33.0's GNU asset stays broken. Affected users can use `cook-x86_64-unknown-linux-musl.tar.gz` in the meantime — it's static and runs on Debian 12 today.
- `cook update` needs no code change, but `src/update.rs:118-123` routes every non-musl Linux to the GNU asset, so affected users can't self-update out of this — they need one manual re-download once a fixed release ships.
- Worth following up with a CI guard that checks the built GNU binary's `.gnu.version_r` against a chosen floor, so this can't regress silently again. Not included here.