### PR TITLE
fix: disable bundled_units so quantities keep their authored units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,14 +753,10 @@ dependencies = [
  "enum-map",
  "finl_unicode",
  "indexmap",
- "prettyplease",
- "proc-macro2",
- "quote",
  "serde",
  "serde_yaml",
  "smallvec",
  "strum",
- "syn 2.0.118",
  "thiserror 2.0.19",
  "toml 0.8.23",
  "toml_edit",
@@ -2969,16 +2965,6 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,12 @@ camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 base64 = { version = "0.23", optional = true }
-# bundled_units carries the unit database (quantity scaling, unit normalisation).
-# We rely on it in `cook recipe`, but never declared it: it was reaching us only
-# via feature unification from cooklang-language-server / cooklang-reports, which
-# depend on cooklang with default features. Declare it where it is actually used.
-cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "bundled_units", "pantry", "shopping_list"] }
+# bundled_units is deliberately NOT enabled: it carries the unit database, and with
+# it Converter::default() silently converts quantities to a "best" unit (e.g.
+# 5/8 cup -> 10 tbsp) and approximates fractions. Without it the converter is empty
+# and quantities stay as authored. If it ever comes back, some dep is leaking it
+# through feature unification (`cargo tree -e features -i cooklang`).
+cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "pantry", "shopping_list"] }
 cooklang-find = { version = "0.6.1", default-features = false }
 cooklang-import = { version = "0.9.14", optional = true }
 cooklang-sync-client = { version = "0.5.0", optional = true }

--- a/tests/snapshots/snapshot_test__recipe_human_output.snap
+++ b/tests/snapshots/snapshot_test__recipe_human_output.snap
@@ -7,9 +7,9 @@ expression: stdout
 servings: 2
 
 Ingredients:
-  pasta      200 g 
-  salt       1 tsp 
-  water      2 c   
+  pasta      200 g  
+  salt       1 tsp  
+  water      2 cups 
 
 Cookware:
   pot      
@@ -17,4 +17,4 @@ Cookware:
 Steps:
  1. Boil water for 5 minutes. Add salt and pasta. Cook in a pot for another
     10 minutes.
-     [water: 2 c, salt: 1 tsp, pasta: 200 g]
+     [water: 2 cups, salt: 1 tsp, pasta: 200 g]

--- a/tests/snapshots/snapshot_test__recipe_json_output.snap
+++ b/tests/snapshots/snapshot_test__recipe_json_output.snap
@@ -24,8 +24,8 @@ expression: formatted
       "name": "water",
       "note": null,
       "quantity": {
-        "scalable": false,
-        "unit": "c",
+        "scalable": true,
+        "unit": "cups",
         "value": {
           "type": "number",
           "value": {
@@ -50,7 +50,7 @@ expression: formatted
       "name": "salt",
       "note": null,
       "quantity": {
-        "scalable": false,
+        "scalable": true,
         "unit": "tsp",
         "value": {
           "type": "number",
@@ -76,7 +76,7 @@ expression: formatted
       "name": "pasta",
       "note": null,
       "quantity": {
-        "scalable": false,
+        "scalable": true,
         "unit": "g",
         "value": {
           "type": "number",

--- a/tests/snapshots/snapshot_test__recipe_markdown_output.snap
+++ b/tests/snapshots/snapshot_test__recipe_markdown_output.snap
@@ -12,8 +12,8 @@ name: Pancakes
 
 ## Ingredients
 
-- *2 c* flour
-- *1 1/2 c* milk
+- *2 cups* flour
+- *1.5 cups* milk
 - *2* eggs
 - *2 tbsp* sugar
 

--- a/tests/snapshots/snapshot_test__recipe_yaml_output.snap
+++ b/tests/snapshots/snapshot_test__recipe_yaml_output.snap
@@ -48,8 +48,8 @@ ingredients:
       value:
         type: regular
         value: 2.0
-    unit: c
-    scalable: false
+    unit: cups
+    scalable: true
   note: null
   reference: null
   relation:
@@ -68,7 +68,7 @@ ingredients:
         type: regular
         value: 1.0
     unit: tsp
-    scalable: false
+    scalable: true
   note: null
   reference: null
   relation:
@@ -87,7 +87,7 @@ ingredients:
         type: regular
         value: 200.0
     unit: g
-    scalable: false
+    scalable: true
   note: null
   reference: null
   relation:

--- a/tests/snapshots/snapshot_test__scaled_recipe_output.snap
+++ b/tests/snapshots/snapshot_test__scaled_recipe_output.snap
@@ -24,8 +24,8 @@ expression: formatted
       "name": "water",
       "note": null,
       "quantity": {
-        "scalable": false,
-        "unit": "c",
+        "scalable": true,
+        "unit": "cups",
         "value": {
           "type": "number",
           "value": {
@@ -50,18 +50,13 @@ expression: formatted
       "name": "salt",
       "note": null,
       "quantity": {
-        "scalable": false,
-        "unit": "tbsp",
+        "scalable": true,
+        "unit": "tsp",
         "value": {
           "type": "number",
           "value": {
-            "type": "fraction",
-            "value": {
-              "den": 1,
-              "err": -6.762804893867269e-8,
-              "num": 0,
-              "whole": 1
-            }
+            "type": "regular",
+            "value": 3.0
           }
         }
       },
@@ -81,7 +76,7 @@ expression: formatted
       "name": "pasta",
       "note": null,
       "quantity": {
-        "scalable": false,
+        "scalable": true,
         "unit": "g",
         "value": {
           "type": "number",


### PR DESCRIPTION
## Summary

Disables the cooklang `bundled_units` feature so quantities are displayed exactly as authored, in the units the recipe author wrote.

`bundled_units` loads the full unit database into `Converter::default()`, which:

- silently converted quantities to a "best" unit (`5/8 cup` → `10 tbsp`),
- approximated fractions lossily (`1 5/8` → `1 2/3`, a ~2.6% error presented as exact),
- made the terminal and web UI disagree on the same recipe (web showed `1.625 c`, terminal `1 2/3 c`).

## Root cause

No dependency leaks the feature anymore — `cooklang-reports` and `cooklang-language-server` both declare `cooklang` with `default-features = false`. It was enabled solely by our own explicit declaration in `Cargo.toml`, guarded by a stale comment about past feature unification. The comment now documents why the feature must stay off and how to find a future leak (`cargo tree -e features -i cooklang`).

## Behavior after

With the feature off, `Converter::default()` falls back to `Converter::empty()` (no code changes needed):

```
$ cook recipe units-test.cook   # @milk{1 5/8%cup}, @cocoa{5/8%cup}

Ingredients:
  cocoa      0.625 cup
  milk       1.625 cup
```

Authored units preserved, exact values, full unit names, and terminal/web UI now agree.

## Snapshot changes worth noting

- `scalable` flips `false` → `true`: the old conversion path rebuilt quantities via `Quantity::new`, which hardcodes `scalable: false`, silently dropping the parser's scalable flag. The new value is the correct one.
- The scaled-recipe snapshot loses a floating-point error term (`err: -6.76e-8`) left over from the lossy `3 tsp` → `1 tbsp` round-trip.

Addresses the silent-conversion and web/terminal-consistency parts of #432. The remaining part (opt-in fraction display, e.g. `1 5/8 cups`) stays open there.

## Checks

- `cargo fmt --check`, `cargo clippy`, and the full test suite pass.
