### PR TITLE
fix(ci): tolerate CRLF checkouts in the api docs freshness test

### DIFF
--- a/tests/api_docs_md_test.rs
+++ b/tests/api_docs_md_test.rs
@@ -30,6 +30,9 @@ fn docs_api_md_is_up_to_date() {
             path.display()
         )
     });
+    // Git on Windows may check the file out with CRLF endings; compare content,
+    // not line endings.
+    let actual = actual.replace("\r\n", "\n");
 
     assert_eq!(
         actual, expected,


### PR DESCRIPTION
## Summary
The `docs_api_md_is_up_to_date` test failed on the windows-latest CI runner (seen on #433's Test run): GitHub's Windows runners check files out with `core.autocrlf=true`, so `docs/api.md` arrives with CRLF line endings and no longer byte-matches the LF string `api_docs_md::render()` produces.

The fix normalizes CRLF to LF in the file content before comparing, so the test checks the docs' content rather than the checkout's line-ending convention.

## Test plan
- Reproduced locally by converting `docs/api.md` to CRLF: test failed before the change, passes after.
- Restored the LF file: test still passes.
- `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` all pass.