### PR TITLE
fix(ci): skip the Claude review when its token is unavailable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,13 +26,35 @@ jobs:
       id-token: write
     
     steps:
+      # Dependabot-triggered runs read from the Dependabot secret store, not the
+      # Actions one, so CLAUDE_CODE_OAUTH_TOKEN is empty there and the action
+      # fails validation — a check that can never go green on a dependency PR,
+      # which then blocks `@dependabot merge` forever. Fork PRs get no secrets
+      # either, with the same result. Skip the review instead of failing it, and
+      # say so in the run summary so a genuinely misconfigured token is still
+      # visible. Adding CLAUDE_CODE_OAUTH_TOKEN to the repo's *Dependabot*
+      # secrets is what turns the review back on for dependency PRs.
+      - name: Check for review credentials
+        id: creds
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not available to this run; skipping the review."
+          fi
+
       - name: Checkout repository
+        if: steps.creds.outputs.available == 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.creds.outputs.available == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Problem

Every Dependabot PR has a red `claude-review` check. The cause is not the code under review:

```
Secret source: Dependabot
...
##[error]Action failed with error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation ... is required
```

Dependabot-triggered runs read from the **Dependabot** secret store, not the Actions one, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves to an empty string and the action fails validation before it reviews anything. Fork PRs get no secrets either and fail identically.

This is not cosmetic: `@dependabot merge` waits for CI to pass, so a check that can never pass stalls it indefinitely. That is currently blocking #447, #448, #449, #451, #452 and #453, all of which have fully green `Test` suites.

## Change

Gate the checkout and review steps on the token actually being present. When it isn't, the job skips those steps and succeeds, emitting a `::warning::` so a genuinely misconfigured token is still visible in the run summary rather than silently swallowed.

This deliberately preserves the existing `allowed_bots: "dependabot[bot]"` intent — reviewing dependency PRs is desirable, it has simply never been able to work. Adding `CLAUDE_CODE_OAUTH_TOKEN` to the repository's **Dependabot** secrets (Settings → Secrets and variables → Dependabot) turns the review back on for those PRs, and this workflow then picks it up with no further edit.

## Verification

YAML parses and the two gated steps carry the guard; the credential check itself is ungated so the job always reports. Behaviour on this PR is itself the test: it is not a Dependabot PR, so the token is present and `claude-review` should run and review normally.