### PR TITLE
Sync: clear message + status reason when the server requires a plan (402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,9 +858,8 @@ dependencies = [
 
 [[package]]
 name = "cooklang-sync-client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091a9790342274289a9a9db9a6441488a364323a31312ef040e925a80095e9cc"
+version = "0.5.1"
+source = "git+https://github.com/cooklang/cooklang-sync?rev=3464309f8799732f765fc1d99a01a310cbba3df7#3464309f8799732f765fc1d99a01a310cbba3df7"
 dependencies = [
  "async-stream",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ base64 = { version = "0.23", optional = true }
 cooklang = { version = "0.18.5", default-features = false, features = ["aisle", "pantry", "shopping_list"] }
 cooklang-find = { version = "0.6.1", default-features = false }
 cooklang-import = { version = "0.9.14", optional = true }
-cooklang-sync-client = { version = "0.5.0", optional = true }
+cooklang-sync-client = { git = "https://github.com/cooklang/cooklang-sync", rev = "3464309f8799732f765fc1d99a01a310cbba3df7", optional = true }
 libsqlite3-sys = { version = "0.35", features = ["bundled"], optional = true }
 cooklang-language-server = { version = "0.2.4", optional = true }
 cooklang-reports = { version = "0.5.1" }

--- a/src/server/handlers/sync.rs
+++ b/src/server/handlers/sync.rs
@@ -20,10 +20,15 @@ pub struct SyncStatusResponse {
     pub email: Option<String>,
     pub syncing: bool,
     pub pending_login: Option<PendingLogin>,
+    /// Why sync is currently off, e.g. `"payment_required"`. Absent while
+    /// syncing or when the last stop wasn't a known, user-actionable
+    /// condition. Additive field: older clients that don't read it are
+    /// unaffected.
+    pub reason: Option<String>,
 }
 
 pub async fn sync_status(State(state): State<Arc<AppState>>) -> Json<SyncStatusResponse> {
-    let (logged_in, email, syncing) = state.sync_status().await;
+    let (logged_in, email, syncing, reason) = state.sync_status().await;
 
     let pending_login = {
         let guard = state.pending_device_flow.lock().await;
@@ -43,6 +48,7 @@ pub async fn sync_status(State(state): State<Arc<AppState>>) -> Json<SyncStatusR
         email,
         syncing,
         pending_login,
+        reason,
     })
 }
 
@@ -120,6 +126,7 @@ pub async fn sync_login(
                             db_path,
                         ) {
                             Ok(handle) => {
+                                *state_clone.last_sync_reason.lock().unwrap() = None;
                                 *state_clone.sync_handle.lock().await = Some(handle);
                                 tracing::info!("Sync started after login");
                             }
@@ -165,6 +172,7 @@ pub async fn sync_logout(
     if let Some(handle) = state.sync_handle.lock().await.take() {
         handle.stop().await;
     }
+    *state.last_sync_reason.lock().unwrap() = None;
 
     *state.sync_session.lock().unwrap() = None;
     if let Err(e) = SyncSession::delete(&state.session_path) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -142,6 +142,7 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
                 Ok(db_path) => {
                     match crate::sync::start_sync(session, state.base_path.to_string(), db_path) {
                         Ok(handle) => {
+                            *state.last_sync_reason.lock().unwrap() = None;
                             // Safe to use try_lock here: no contention before the server accepts connections
                             if let Ok(mut guard) = state.sync_handle.try_lock() {
                                 *guard = Some(handle);
@@ -316,6 +317,8 @@ fn build_state(ctx: Context, args: ServerArgs) -> Result<Arc<AppState>> {
         #[cfg(feature = "sync")]
         sync_handle: Arc::new(tokio::sync::Mutex::new(None)),
         #[cfg(feature = "sync")]
+        last_sync_reason: Arc::new(Mutex::new(None)),
+        #[cfg(feature = "sync")]
         pending_device_flow: Arc::new(tokio::sync::Mutex::new(None)),
         #[cfg(feature = "sync")]
         session_path,
@@ -369,6 +372,12 @@ pub struct AppState {
     pub sync_session: Arc<Mutex<Option<crate::sync::SyncSession>>>,
     #[cfg(feature = "sync")]
     pub sync_handle: Arc<tokio::sync::Mutex<Option<crate::sync::SyncHandle>>>,
+    /// Reason the most recent sync task stopped, surfaced by the status
+    /// endpoint after the (now finished) `SyncHandle` that observed it has
+    /// been cleaned up. Cleared whenever a new sync task starts or the user
+    /// logs out.
+    #[cfg(feature = "sync")]
+    pub last_sync_reason: Arc<Mutex<Option<crate::sync::SyncFailureReason>>>,
     #[cfg(feature = "sync")]
     pub pending_device_flow: Arc<tokio::sync::Mutex<Option<crate::sync::PendingDeviceFlow>>>,
     #[cfg(feature = "sync")]
@@ -379,9 +388,11 @@ pub struct AppState {
 
 #[cfg(feature = "sync")]
 impl AppState {
-    /// Check sync status: returns (logged_in, email, syncing).
+    /// Check sync status: returns (logged_in, email, syncing, reason).
+    /// `reason` explains why sync is off (e.g. `"payment_required"`), and is
+    /// `None` while syncing or when the last stop wasn't a known condition.
     /// Cleans up finished sync handles as a side effect.
-    pub async fn sync_status(&self) -> (bool, Option<String>, bool) {
+    pub async fn sync_status(&self) -> (bool, Option<String>, bool, Option<String>) {
         let (logged_in, email) = {
             let session = self.sync_session.lock().unwrap();
             (
@@ -393,14 +404,25 @@ impl AppState {
             let mut guard = self.sync_handle.lock().await;
             match guard.as_ref() {
                 Some(handle) if handle.is_running() => true,
-                Some(_) => {
+                Some(handle) => {
+                    if let Some(reason) = handle.last_error_reason() {
+                        *self.last_sync_reason.lock().unwrap() = Some(reason);
+                    }
                     guard.take();
                     false
                 }
                 None => false,
             }
         };
-        (logged_in, email, syncing)
+        let reason = if syncing {
+            None
+        } else {
+            self.last_sync_reason
+                .lock()
+                .unwrap()
+                .map(|r| r.as_str().to_string())
+        };
+        (logged_in, email, syncing, reason)
     }
 }
 

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -526,7 +526,7 @@ async fn preferences_page(
     Extension(features): Extension<FeatureFlags>,
 ) -> impl askama_axum::IntoResponse {
     #[cfg(feature = "sync")]
-    let (sync_logged_in, sync_email, sync_syncing) = state.sync_status().await;
+    let (sync_logged_in, sync_email, sync_syncing, _sync_reason) = state.sync_status().await;
     #[cfg(not(feature = "sync"))]
     let (sync_logged_in, sync_email, sync_syncing) = (false, None, false);
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,7 +3,7 @@ pub mod endpoints;
 pub mod runner;
 pub mod session;
 
-pub use runner::{start_sync, SyncHandle};
+pub use runner::{start_sync, SyncFailureReason, SyncHandle};
 pub use session::SyncSession;
 
 use tokio_util::sync::CancellationToken;

--- a/src/sync/runner.rs
+++ b/src/sync/runner.rs
@@ -1,22 +1,59 @@
 use super::endpoints;
 use super::session::{self, SyncSession};
 use anyhow::{Context, Result};
+use cooklang_sync_client::errors::SyncError;
 use cooklang_sync_client::SyncContext;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+
+/// A known, user-actionable reason the sync task stopped. Surfaced to the
+/// local web UI via the sync status endpoint so it can explain why sync is
+/// off instead of just showing it as stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncFailureReason {
+    /// The sync server rejected the account with HTTP 402: no active plan.
+    PaymentRequired,
+}
+
+impl SyncFailureReason {
+    /// Stable wire value used in the sync status JSON response.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SyncFailureReason::PaymentRequired => "payment_required",
+        }
+    }
+}
+
+/// Maps a sync task's terminal error to a known, user-actionable reason, if
+/// any. `None` means the error isn't one we surface specially to the UI —
+/// it's still logged in full by the caller.
+fn classify_sync_error(err: &SyncError) -> Option<SyncFailureReason> {
+    match err {
+        SyncError::PaymentRequired => Some(SyncFailureReason::PaymentRequired),
+        _ => None,
+    }
+}
 
 /// Holds the running sync task handle and cancellation token.
 pub struct SyncHandle {
     context: Arc<SyncContext>,
     task: JoinHandle<()>,
+    last_error: Arc<Mutex<Option<SyncFailureReason>>>,
 }
 
 impl SyncHandle {
     /// Check if the sync task is still running.
     pub fn is_running(&self) -> bool {
         !self.task.is_finished()
+    }
+
+    /// The reason the sync task most recently stopped, if it was a known,
+    /// user-actionable condition. `None` if it's still running, finished
+    /// cleanly, or failed for an unclassified reason.
+    pub fn last_error_reason(&self) -> Option<SyncFailureReason> {
+        *self.last_error.lock().unwrap()
     }
 
     /// Stop the sync task gracefully.
@@ -47,6 +84,9 @@ pub fn start_sync(
 
     tracing::info!("Starting sync for directory: {recipes_dir}");
 
+    let last_error = Arc::new(Mutex::new(None));
+    let last_error_for_task = Arc::clone(&last_error);
+
     let ctx = context.clone();
     let task = tokio::spawn(async move {
         let result = cooklang_sync_client::run_async(
@@ -62,11 +102,36 @@ pub fn start_sync(
 
         match result {
             Ok(()) => tracing::info!("Sync task finished"),
-            Err(e) => tracing::error!("Sync task failed: {e:?}"),
+            Err(e) => {
+                // `run_async` does not retry internally (indexer/syncer return on
+                // first error and `try_join!` propagates it), and nothing here
+                // restarts the task automatically, so any error — including
+                // PaymentRequired — ends the sync task for the rest of the
+                // session rather than tight-looping. The user has to log in
+                // again or restart `cook server` to retry.
+                if let Some(reason) = classify_sync_error(&e) {
+                    *last_error_for_task.lock().unwrap() = Some(reason);
+                }
+                match e {
+                    SyncError::PaymentRequired => {
+                        tracing::error!(
+                            "Sync task failed: account has no sync plan (402 Payment Required)"
+                        );
+                        eprintln!(
+                            "sync: your account has no sync plan — subscribe at https://cook.md/pricing (your files are untouched)"
+                        );
+                    }
+                    e => tracing::error!("Sync task failed: {e:?}"),
+                }
+            }
         }
     });
 
-    Ok(SyncHandle { context, task })
+    Ok(SyncHandle {
+        context,
+        task,
+        last_error,
+    })
 }
 
 /// Start a background token refresh task. Checks hourly, refreshes if < 1 hour remaining.
@@ -151,4 +216,34 @@ async fn refresh_token(client: &reqwest::Client, current_token: &str) -> Result<
     }
     let data: R = resp.json().await?;
     Ok(data.token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payment_required_reason_has_stable_wire_value() {
+        assert_eq!(
+            SyncFailureReason::PaymentRequired.as_str(),
+            "payment_required"
+        );
+    }
+
+    #[test]
+    fn classifies_payment_required_as_payment_required() {
+        assert_eq!(
+            classify_sync_error(&SyncError::PaymentRequired),
+            Some(SyncFailureReason::PaymentRequired)
+        );
+    }
+
+    #[test]
+    fn does_not_classify_other_errors() {
+        assert_eq!(classify_sync_error(&SyncError::Unauthorized), None);
+        assert_eq!(
+            classify_sync_error(&SyncError::Unknown("boom".to_string())),
+            None
+        );
+    }
 }


### PR DESCRIPTION
D3 of the sync-enforcement rollout. SyncError::PaymentRequired → one stderr line ('sync: your account has no sync plan — subscribe at https://cook.md/pricing (your files are untouched)') + tracing log; additive reason field ('payment_required') on the sync status response for the local web UI; a 402 is terminal for the session (verified one-shot, no retry loop). Client crate pinned to cooklang-sync@3464309f. Reviewed: ship (777 tests, 0 failures; lock diff is the single pin block).