### PR TITLE
Renew session tokens eagerly (on-start heal + 24h cadence) so server-minted claims propagate

### DIFF
--- a/src/sync/runner.rs
+++ b/src/sync/runner.rs
@@ -5,6 +5,7 @@ use cooklang_sync_client::errors::SyncError;
 use cooklang_sync_client::SyncContext;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -134,8 +135,156 @@ pub fn start_sync(
     })
 }
 
-/// Start a background token refresh task. Checks hourly, refreshes if < 1 hour remaining.
-/// Returns a JoinHandle so the caller can cancel via the provided token.
+/// A JWT should be renewed if it's close to expiring, if it's been a while
+/// since the last successful renewal in this process, or if it needs the
+/// one-time "heal" renewal for a token that predates the sync-enforcement
+/// rollout (see `jwt_lacks_sync_until_claim`'s doc comment). Pure so the
+/// decision table is exercised directly in tests below.
+///
+/// - `expires_in_secs`: seconds remaining until the JWT expires (may be
+///   negative if it has already expired).
+/// - `since_last_renew_secs`: seconds since the last successful renewal —
+///   either in this process, or (when this process hasn't renewed yet)
+///   derived from the session file's mtime. `None` when neither is
+///   available (fresh process, no session file to stat).
+/// - `claim_missing_and_not_yet_healed`: true when the JWT has no
+///   `sync_until` claim and the once-per-boot heal renewal for that hasn't
+///   run yet.
+fn should_renew(
+    expires_in_secs: i64,
+    since_last_renew_secs: Option<i64>,
+    claim_missing_and_not_yet_healed: bool,
+) -> bool {
+    /// Must be larger than the check interval (1 hour) to ensure the token
+    /// is always refreshed before it expires.
+    const RENEW_THRESHOLD_SECS: i64 = 7200; // 2 hours
+    const RENEW_CADENCE_SECS: i64 = 86400; // 24 hours
+
+    claim_missing_and_not_yet_healed
+        || expires_in_secs < RENEW_THRESHOLD_SECS
+        || matches!(since_last_renew_secs, Some(secs) if secs >= RENEW_CADENCE_SECS)
+}
+
+/// Seconds since `path` was last modified, or `None` if its metadata can't
+/// be read (missing file, unsupported platform, clock skew, etc).
+fn file_age_secs(path: &Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    Some(modified.elapsed().ok()?.as_secs() as i64)
+}
+
+/// Check the current session's JWT and renew it if `should_renew` says so.
+/// Shared by the boot-time heal check and the periodic loop in
+/// `start_token_refresh` so both go through the exact same decision logic.
+async fn check_and_maybe_renew(
+    client: &reqwest::Client,
+    session_state: &Arc<std::sync::Mutex<Option<SyncSession>>>,
+    session_path: &Path,
+    last_renewed_at: &mut Option<Instant>,
+    claim_heal_attempted: &mut bool,
+) {
+    let jwt = {
+        let guard = session_state.lock().unwrap();
+        match guard.as_ref() {
+            Some(s) => s.jwt.clone(),
+            None => return,
+        }
+    };
+
+    let expires_in = match session::jwt_expires_in(&jwt) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Invalid JWT: {e}");
+            let _ = SyncSession::delete(session_path);
+            *session_state.lock().unwrap() = None;
+            return;
+        }
+    };
+
+    // Only ever force a renewal on the missing-claim signal once per boot:
+    // a free-tier token lacks `sync_until` permanently (not just until
+    // healed), so re-checking this every tick would renew forever for
+    // free users.
+    let claim_missing_and_not_yet_healed =
+        !*claim_heal_attempted && session::jwt_lacks_sync_until_claim(&jwt).unwrap_or(false);
+
+    let since_last_renew = last_renewed_at
+        .map(|t| t.elapsed().as_secs() as i64)
+        .or_else(|| file_age_secs(session_path));
+
+    if !should_renew(
+        expires_in,
+        since_last_renew,
+        claim_missing_and_not_yet_healed,
+    ) {
+        return;
+    }
+
+    tracing::info!("JWT needs refresh");
+    if claim_missing_and_not_yet_healed {
+        // One attempt, win or lose — see the comment above.
+        *claim_heal_attempted = true;
+    }
+
+    apply_renew_outcome(
+        refresh_token(client, &jwt).await,
+        session_state,
+        session_path,
+        last_renewed_at,
+    );
+}
+
+/// Applies the outcome of a `refresh_token` call to the in-memory session
+/// and the session file. Split out from `check_and_maybe_renew` so the two
+/// meaningfully different failure modes can be exercised directly in tests
+/// without a real HTTP round trip:
+///
+/// - a rejected auth (`RenewError::AuthRejected`, HTTP 401) means the
+///   account was logged out, deleted, or otherwise had its session revoked
+///   server-side — retrying with the same token will never succeed, so this
+///   restores the old blanket behavior: delete the session file, clear the
+///   in-memory session, and let the existing "no session" pathway (the same
+///   one `SyncSession::load` uses for a naturally-expired token) tell the
+///   local UI a re-login is needed.
+/// - anything else (`RenewError::Transient`: network failure, timeout,
+///   non-401 non-2xx, unexpected body) keeps the old token and logs —
+///   worth retrying next tick, not a reason to log the user out.
+fn apply_renew_outcome(
+    outcome: Result<String, RenewError>,
+    session_state: &Arc<std::sync::Mutex<Option<SyncSession>>>,
+    session_path: &Path,
+    last_renewed_at: &mut Option<Instant>,
+) {
+    match outcome {
+        Ok(new_jwt) => match SyncSession::from_jwt(new_jwt) {
+            Ok(new_session) => {
+                if let Err(e) = new_session.save(session_path) {
+                    tracing::error!("Failed to save refreshed session: {e}");
+                }
+                *session_state.lock().unwrap() = Some(new_session);
+                *last_renewed_at = Some(Instant::now());
+                tracing::info!("JWT refreshed successfully");
+            }
+            Err(e) => tracing::error!("Failed to parse refreshed JWT: {e}"),
+        },
+        Err(RenewError::AuthRejected) => {
+            tracing::warn!(
+                "Session rejected by the server (401 Unauthorized); clearing session, re-login required"
+            );
+            let _ = SyncSession::delete(session_path);
+            *session_state.lock().unwrap() = None;
+        }
+        Err(RenewError::Transient(e)) => {
+            tracing::error!("Failed to refresh JWT: {e}");
+        }
+    }
+}
+
+/// Start a background token refresh task. Checks immediately (this is what
+/// heals a session whose JWT predates the sync-enforcement rollout — see
+/// `jwt_lacks_sync_until_claim`), then hourly; renews when < 2 hours of
+/// token life remain or when ≥ 24 hours have passed since the last
+/// successful renewal. Returns a JoinHandle so the caller can cancel via the
+/// provided token.
 pub fn start_token_refresh(
     session_state: Arc<std::sync::Mutex<Option<SyncSession>>>,
     session_path: impl AsRef<Path> + Send + 'static,
@@ -144,8 +293,21 @@ pub fn start_token_refresh(
     let session_path = session_path.as_ref().to_path_buf();
     let client = reqwest::Client::new();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(3600));
-        interval.tick().await; // skip the immediate first tick
+        let mut last_renewed_at: Option<Instant> = None;
+        let mut claim_heal_attempted = false;
+
+        // Immediate check at boot, before waiting for the first hourly tick.
+        check_and_maybe_renew(
+            &client,
+            &session_state,
+            &session_path,
+            &mut last_renewed_at,
+            &mut claim_heal_attempted,
+        )
+        .await;
+
+        let mut interval = tokio::time::interval(Duration::from_secs(3600));
+        interval.tick().await; // consume the interval's own immediate first tick; we already checked above
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => {
@@ -155,66 +317,75 @@ pub fn start_token_refresh(
                 _ = interval.tick() => {}
             }
 
-            let jwt = {
-                let guard = session_state.lock().unwrap();
-                match guard.as_ref() {
-                    Some(s) => s.jwt.clone(),
-                    None => continue,
-                }
-            };
-
-            match session::should_refresh_jwt(&jwt) {
-                Ok(true) => {
-                    tracing::info!("JWT needs refresh");
-                    match refresh_token(&client, &jwt).await {
-                        Ok(new_jwt) => match SyncSession::from_jwt(new_jwt) {
-                            Ok(new_session) => {
-                                if let Err(e) = new_session.save(&session_path) {
-                                    tracing::error!("Failed to save refreshed session: {e}");
-                                }
-                                *session_state.lock().unwrap() = Some(new_session);
-                                tracing::info!("JWT refreshed successfully");
-                            }
-                            Err(e) => tracing::error!("Failed to parse refreshed JWT: {e}"),
-                        },
-                        Err(e) => {
-                            tracing::error!("Failed to refresh JWT: {e}");
-                            let _ = SyncSession::delete(&session_path);
-                            *session_state.lock().unwrap() = None;
-                        }
-                    }
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    tracing::error!("Invalid JWT: {e}");
-                    let _ = SyncSession::delete(&session_path);
-                    *session_state.lock().unwrap() = None;
-                }
-            }
+            check_and_maybe_renew(
+                &client,
+                &session_state,
+                &session_path,
+                &mut last_renewed_at,
+                &mut claim_heal_attempted,
+            )
+            .await;
         }
     })
 }
 
-async fn refresh_token(client: &reqwest::Client, current_token: &str) -> Result<String> {
+/// Why a `/api/sessions/renew` call failed.
+#[derive(Debug)]
+enum RenewError {
+    /// HTTP 401: the server rejected the token itself — the account was
+    /// logged out, deleted, or otherwise had its session revoked
+    /// server-side. Retrying with the same token will never succeed.
+    AuthRejected,
+    /// Anything else: a network failure, a timeout, a non-401 non-2xx
+    /// status, or an unexpected response body. The token itself may still
+    /// be fine — worth retrying on the next tick.
+    Transient(anyhow::Error),
+}
+
+impl std::fmt::Display for RenewError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RenewError::AuthRejected => write!(f, "authentication rejected (401 Unauthorized)"),
+            RenewError::Transient(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// Pure: classifies a non-2xx `/api/sessions/renew` response status as an
+/// auth rejection (401 only) or a transient failure. Never called with a
+/// success status.
+fn classify_renew_failure(status: reqwest::StatusCode) -> RenewError {
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        RenewError::AuthRejected
+    } else {
+        RenewError::Transient(anyhow::anyhow!("Token refresh failed: {status}"))
+    }
+}
+
+async fn refresh_token(
+    client: &reqwest::Client,
+    current_token: &str,
+) -> Result<String, RenewError> {
     let url = format!("{}/sessions/renew", endpoints::api_endpoint());
     let resp = client
         .post(&url)
         .header("Authorization", format!("Bearer {current_token}"))
         .send()
-        .await?;
+        .await
+        .map_err(|e| RenewError::Transient(e.into()))?;
 
-    if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-        anyhow::bail!("Authentication expired");
-    }
     if !resp.status().is_success() {
-        anyhow::bail!("Token refresh failed: {}", resp.status());
+        return Err(classify_renew_failure(resp.status()));
     }
 
     #[derive(serde::Deserialize)]
     struct R {
         token: String,
     }
-    let data: R = resp.json().await?;
+    let data: R = resp
+        .json()
+        .await
+        .map_err(|e| RenewError::Transient(e.into()))?;
     Ok(data.token)
 }
 
@@ -245,5 +416,233 @@ mod tests {
             classify_sync_error(&SyncError::Unknown("boom".to_string())),
             None
         );
+    }
+
+    // should_renew truth table. Columns: expires_in_secs, since_last_renew_secs,
+    // claim_missing_and_not_yet_healed -> expected.
+    const ONE_HOUR: i64 = 3600;
+    const THREE_HOURS: i64 = 3 * 3600;
+    const TWENTY_THREE_HOURS: i64 = 23 * 3600;
+    const TWENTY_FIVE_HOURS: i64 = 25 * 3600;
+
+    #[test]
+    fn healthy_token_far_from_expiry_recently_renewed_does_not_renew() {
+        assert!(!should_renew(THREE_HOURS, Some(ONE_HOUR), false));
+    }
+
+    #[test]
+    fn renews_when_less_than_two_hours_remain() {
+        assert!(should_renew(ONE_HOUR, Some(ONE_HOUR), false));
+    }
+
+    #[test]
+    fn does_not_renew_at_exactly_two_hours_remaining() {
+        // The threshold is a strict "<", not "<=".
+        assert!(!should_renew(7200, Some(ONE_HOUR), false));
+    }
+
+    #[test]
+    fn renews_when_already_expired() {
+        assert!(should_renew(-1, Some(ONE_HOUR), false));
+    }
+
+    #[test]
+    fn renews_when_24h_have_passed_since_last_renewal() {
+        assert!(should_renew(THREE_HOURS, Some(TWENTY_FIVE_HOURS), false));
+    }
+
+    #[test]
+    fn does_not_renew_before_24h_cadence_elapses() {
+        assert!(!should_renew(THREE_HOURS, Some(TWENTY_THREE_HOURS), false));
+    }
+
+    #[test]
+    fn renews_at_exactly_24h_cadence() {
+        assert!(should_renew(THREE_HOURS, Some(86400), false));
+    }
+
+    #[test]
+    fn no_prior_renewal_and_healthy_token_does_not_force_renewal() {
+        // `None` means "no successful renewal yet this process, and no file
+        // mtime to fall back on" — absent any other reason, that alone must
+        // not force a renewal (a process restart shouldn't hammer the
+        // renew endpoint every time `cook server` starts for a healthy
+        // long-lived token).
+        assert!(!should_renew(THREE_HOURS, None, false));
+    }
+
+    #[test]
+    fn missing_claim_and_not_yet_healed_forces_renewal_even_when_otherwise_healthy() {
+        assert!(should_renew(THREE_HOURS, Some(ONE_HOUR), true));
+    }
+
+    #[test]
+    fn missing_claim_forces_renewal_even_with_no_prior_renewal_recorded() {
+        assert!(should_renew(THREE_HOURS, None, true));
+    }
+
+    #[test]
+    fn all_three_conditions_true_still_renews() {
+        assert!(should_renew(-1, Some(TWENTY_FIVE_HOURS), true));
+    }
+
+    #[test]
+    fn file_age_secs_is_none_for_missing_file() {
+        assert_eq!(
+            file_age_secs(Path::new("/nonexistent/path/session.json")),
+            None
+        );
+    }
+
+    #[test]
+    fn file_age_secs_reports_recent_write_as_near_zero() {
+        let dir = std::env::temp_dir().join(format!(
+            "cookcli-runner-test-{}-{:?}",
+            std::process::id(),
+            Instant::now()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("session.json");
+        std::fs::write(&path, "{}").unwrap();
+
+        let age = file_age_secs(&path).expect("metadata should be readable");
+        assert!(
+            age < 5,
+            "expected a freshly written file to be young, got {age}s"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- 401 vs transient renew failures --------------------------------
+
+    #[test]
+    fn classifies_401_as_auth_rejected() {
+        assert!(matches!(
+            classify_renew_failure(reqwest::StatusCode::UNAUTHORIZED),
+            RenewError::AuthRejected
+        ));
+    }
+
+    #[test]
+    fn classifies_503_as_transient() {
+        assert!(matches!(
+            classify_renew_failure(reqwest::StatusCode::SERVICE_UNAVAILABLE),
+            RenewError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_other_4xx_as_transient_not_auth_rejected() {
+        // Only a 401 means the *token* was rejected; a 404/500/etc is not
+        // grounds for logging the user out.
+        assert!(matches!(
+            classify_renew_failure(reqwest::StatusCode::NOT_FOUND),
+            RenewError::Transient(_)
+        ));
+    }
+
+    fn sample_session() -> SyncSession {
+        SyncSession {
+            jwt: "header.payload.signature".to_string(),
+            user_id: "1".to_string(),
+            email: Some("user@example.com".to_string()),
+        }
+    }
+
+    fn temp_session_path(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cookcli-runner-test-{label}-{}-{:?}",
+            std::process::id(),
+            Instant::now()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("session.json")
+    }
+
+    #[test]
+    fn auth_rejected_clears_the_session_and_deletes_the_file() {
+        let path = temp_session_path("auth-rejected");
+        let session = sample_session();
+        session.save(&path).unwrap();
+        let session_state = Arc::new(Mutex::new(Some(session)));
+        let mut last_renewed_at: Option<Instant> = None;
+
+        apply_renew_outcome(
+            Err(RenewError::AuthRejected),
+            &session_state,
+            &path,
+            &mut last_renewed_at,
+        );
+
+        assert!(
+            session_state.lock().unwrap().is_none(),
+            "a 401 must clear the in-memory session"
+        );
+        assert!(!path.exists(), "a 401 must delete the session file");
+        assert!(last_renewed_at.is_none());
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn transient_failure_keeps_the_session_and_the_file() {
+        let path = temp_session_path("transient");
+        let session = sample_session();
+        session.save(&path).unwrap();
+        let session_state = Arc::new(Mutex::new(Some(session.clone())));
+        let mut last_renewed_at: Option<Instant> = None;
+
+        apply_renew_outcome(
+            Err(RenewError::Transient(anyhow::anyhow!(
+                "Token refresh failed: 503 Service Unavailable"
+            ))),
+            &session_state,
+            &path,
+            &mut last_renewed_at,
+        );
+
+        let guard = session_state.lock().unwrap();
+        assert_eq!(
+            guard.as_ref().map(|s| s.jwt.as_str()),
+            Some(session.jwt.as_str()),
+            "a transient failure must keep the old token for the next tick"
+        );
+        drop(guard);
+        assert!(
+            path.exists(),
+            "a transient failure must not delete the session file"
+        );
+        assert!(last_renewed_at.is_none());
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn successful_renewal_replaces_the_session_and_records_the_time() {
+        let path = temp_session_path("success");
+        let old_session = sample_session();
+        old_session.save(&path).unwrap();
+        let session_state = Arc::new(Mutex::new(Some(old_session)));
+        let mut last_renewed_at: Option<Instant> = None;
+
+        let new_jwt = crate::sync::session::tests_support::make_test_jwt(
+            "2",
+            chrono::Utc::now().timestamp() + 100 * 24 * 3600,
+        );
+
+        apply_renew_outcome(
+            Ok(new_jwt.clone()),
+            &session_state,
+            &path,
+            &mut last_renewed_at,
+        );
+
+        let guard = session_state.lock().unwrap();
+        assert_eq!(guard.as_ref().unwrap().jwt, new_jwt);
+        drop(guard);
+        assert!(last_renewed_at.is_some());
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 }

--- a/src/sync/session.rs
+++ b/src/sync/session.rs
@@ -22,6 +22,13 @@ struct JwtClaims {
     uid: UserId,
     exp: i64,
     email: Option<String>,
+    /// Unix timestamp through which the account's sync entitlement is
+    /// active. Only present on tokens minted after the sync-enforcement
+    /// rollout for accounts that currently have the entitlement; absent
+    /// entirely on older tokens and on free-tier accounts. Presence (not
+    /// value) is what callers care about — see `jwt_lacks_sync_until_claim`.
+    #[serde(default)]
+    sync_until: Option<i64>,
 }
 
 impl SyncSession {
@@ -113,11 +120,120 @@ fn is_jwt_expired(jwt: &str) -> Result<bool> {
     Ok(claims.exp <= chrono::Utc::now().timestamp())
 }
 
-/// Check if a JWT should be refreshed (less than 2 hours remaining).
-/// The threshold must be larger than the refresh interval (1 hour) to ensure
-/// the token is always refreshed before it expires.
-pub fn should_refresh_jwt(jwt: &str) -> Result<bool> {
+/// Seconds remaining until the JWT expires. Negative if it has already
+/// expired.
+pub fn jwt_expires_in(jwt: &str) -> Result<i64> {
     let claims = decode_jwt_claims(jwt)?;
-    let remaining = claims.exp - chrono::Utc::now().timestamp();
-    Ok(remaining < 7200)
+    Ok(claims.exp - chrono::Utc::now().timestamp())
+}
+
+/// True if the JWT's payload has no `sync_until` claim at all.
+///
+/// The server only started minting this claim once the sync-enforcement
+/// rollout shipped, and only for accounts with an active sync entitlement.
+/// A token predating the rollout lacks the claim entirely, and so does a
+/// perfectly healthy free-tier token — this function can't distinguish the
+/// two, which is why callers must renew *at most once per process* on this
+/// signal (see `runner::start_token_refresh`): a paid account's stale token
+/// gets healed, and a free account's token is renewed once and then left
+/// alone.
+pub fn jwt_lacks_sync_until_claim(jwt: &str) -> Result<bool> {
+    let claims = decode_jwt_claims(jwt)?;
+    Ok(claims.sync_until.is_none())
+}
+
+/// Test-only JWT building, shared with other modules' test code (e.g.
+/// `runner::tests`) that need a well-formed token but don't care about its
+/// claims beyond `uid`/`exp`.
+#[cfg(test)]
+pub(crate) mod tests_support {
+    use super::*;
+
+    /// Builds an unsigned test JWT carrying only `uid`/`exp`/`email: null`
+    /// (no `sync_until`), using the same base64url-no-pad encoding the
+    /// server uses (and that `decode_jwt_claims` accepts).
+    pub(crate) fn make_test_jwt(user_id: &str, exp: i64) -> String {
+        let header = general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
+        let payload = general_purpose::URL_SAFE_NO_PAD.encode(
+            serde_json::json!({ "uid": user_id, "exp": exp, "email": serde_json::Value::Null })
+                .to_string(),
+        );
+        format!("{header}.{payload}.signature")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Builds an unsigned test JWT with the given payload, using the same
+    /// base64url-no-pad encoding the server uses (and that `decode_jwt_claims`
+    /// accepts).
+    fn make_jwt(payload: serde_json::Value) -> String {
+        let header = general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
+        let payload = general_purpose::URL_SAFE_NO_PAD.encode(payload.to_string());
+        format!("{header}.{payload}.signature")
+    }
+
+    fn future_exp() -> i64 {
+        chrono::Utc::now().timestamp() + 100 * 24 * 3600 // 100 days out
+    }
+
+    #[test]
+    fn jwt_without_sync_until_is_detected_as_missing() {
+        let jwt = make_jwt(json!({
+            "uid": 42,
+            "exp": future_exp(),
+            "email": "user@example.com",
+        }));
+        assert!(jwt_lacks_sync_until_claim(&jwt).unwrap());
+    }
+
+    #[test]
+    fn jwt_with_sync_until_is_detected_as_present() {
+        let jwt = make_jwt(json!({
+            "uid": 42,
+            "exp": future_exp(),
+            "email": "user@example.com",
+            "sync_until": future_exp(),
+        }));
+        assert!(!jwt_lacks_sync_until_claim(&jwt).unwrap());
+    }
+
+    #[test]
+    fn jwt_with_null_sync_until_is_treated_as_missing() {
+        let jwt = make_jwt(json!({
+            "uid": 42,
+            "exp": future_exp(),
+            "email": "user@example.com",
+            "sync_until": null,
+        }));
+        assert!(jwt_lacks_sync_until_claim(&jwt).unwrap());
+    }
+
+    #[test]
+    fn jwt_expires_in_reflects_remaining_lifetime() {
+        let exp = chrono::Utc::now().timestamp() + 3600;
+        let jwt = make_jwt(json!({
+            "uid": 1,
+            "exp": exp,
+            "email": null,
+        }));
+        let remaining = jwt_expires_in(&jwt).unwrap();
+        // Allow a little slack for the time elapsed during the test itself.
+        assert!((3595..=3600).contains(&remaining), "remaining={remaining}");
+    }
+
+    #[test]
+    fn string_user_id_is_supported() {
+        let jwt = make_jwt(json!({
+            "uid": "abc-123",
+            "exp": future_exp(),
+            "email": null,
+        }));
+        let session = SyncSession::from_jwt(jwt).unwrap();
+        assert_eq!(session.user_id, "abc-123");
+        assert!(jwt_lacks_sync_until_claim(&session.jwt).unwrap());
+    }
 }


### PR DESCRIPTION
## Why

Part of the server-side sync-enforcement rollout: the sync server now mints a `sync_until` (unix ts) claim on every renewed JWT when the account has the sync entitlement. Tokens minted before that rollout — and, unavoidably, any token in a session file loaded at `cook server` boot — carry no such claim at all. CookCLI's session tokens live 100 days, and the renewal threshold was "renew only when < 2h of life remains," so existing sessions would have gone ~100 days before ever hitting the server again and picking up the claim.

This brings CookCLI's renewal cadence in line with the other Cooklang clients: sync-agent renews when near expiry OR ≥24h since last refresh; the editor renews on start + every 24h.

## What changed

- `src/sync/session.rs`
  - `JwtClaims` gains `sync_until: Option<i64>` (`#[serde(default)]`) — presence, not value, is what matters client-side.
  - New `jwt_expires_in(jwt) -> Result<i64>` and `jwt_lacks_sync_until_claim(jwt) -> Result<bool>`, both built on the existing unverified-decode helper.
  - Removed the now-superseded `should_refresh_jwt` (folded into the above + the new decision function).
  - `pub(crate) tests_support::make_test_jwt` — a small cross-module test helper so `runner`'s tests can build a well-formed JWT without duplicating the encoding logic.
  - Unit tests decode hand-built JWTs (base64url, `alg: none`) with the claim present, absent, and explicitly `null`.

- `src/sync/runner.rs`
  - Renew decision extracted into a pure function:
    `should_renew(expires_in_secs, since_last_renew_secs, claim_missing_and_not_yet_healed) -> bool`
    - renews when `expires_in_secs < 7200` (2h) — unchanged
    - renews when `since_last_renew_secs >= 86400` (24h) — new cadence
    - renews unconditionally when `claim_missing_and_not_yet_healed` — the on-start heal
  - `start_token_refresh` now runs an immediate check at boot (heals a session missing `sync_until` without waiting for the first hourly tick), then continues on the existing hourly cadence. Both the boot check and the loop go through one shared `check_and_maybe_renew` so the decision logic isn't duplicated.
  - "Since last renew" is tracked in-memory (no session-file schema change); when this process hasn't renewed yet, it falls back to the session file's mtime, so a `cook server` restart doesn't reset the 24h clock to zero.
  - The missing-claim trigger fires **at most once per process boot** (tracked with a bool): a free-tier token lacks `sync_until` permanently, not just until healed, so re-checking it every tick would otherwise hit `/api/sessions/renew` every hour forever for free users.
  - Renewal failures are now split by cause (see "Review fix" below), instead of one anyhow error for every kind of failure.
  - Full truth table for `should_renew` covered by unit tests, plus tests for the mtime fallback helper.

No changes to login/logout flows or the session file format.

## Review fix: 401 vs. transient renewal failures

An earlier version of this PR collapsed every `/api/sessions/renew` failure — a hard 401 as much as a network blip — into the same `anyhow::Error`, and kept the old token unconditionally on any of them. That meant a revoked/deleted account (or any other reason the server hands back a 401) would retry forever with sync silently dead and no way for the local UI to tell the user to re-login.

Fixed by typing the failure:

- `refresh_token` now returns `Result<String, RenewError>`, with `RenewError` split into:
  - `AuthRejected` — HTTP 401 specifically. The token itself was rejected; retrying with the same token can never succeed.
  - `Transient(anyhow::Error)` — everything else: network failure, timeout, non-401 non-2xx, unexpected body.
- `classify_renew_failure(status) -> RenewError` is a pure function doing just the status-code split (401 vs. everything else), independently unit-tested.
- `apply_renew_outcome(...)` (split out of `check_and_maybe_renew` for testability) now branches on the two cases:
  - `AuthRejected` → **restores the pre-fix/original behavior for this case only**: delete the session file, clear the in-memory session. This reuses the exact same "no session" pathway `SyncSession::load` already uses for a naturally-expired token, so the local UI's existing `sync_logged_in == false` → "Login to CookCloud" rendering picks it up automatically — no new status/reason plumbing needed.
  - `Transient` → unchanged from before: log and keep the old token for the next tick.
- New tests: `classifies_401_as_auth_rejected`, `classifies_503_as_transient`, `classifies_other_4xx_as_transient_not_auth_rejected` (a 404/500/etc is not grounds to log the user out — only 401 is), `auth_rejected_clears_the_session_and_deletes_the_file`, `transient_failure_keeps_the_session_and_the_file`, `successful_renewal_replaces_the_session_and_records_the_time`.

## Verification

- `cargo build --features sync` — clean
- `cargo test --workspace` — all passing (105 in the main test binary, including 26 new/changed tests in `sync::runner` and `sync::session`)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Notes

- Point 3 of the original spec ("renewal failures keep current behavior... never delete the session on a failed renew") was actually a **behavior change** for non-401 failures, not a no-op: the prior code deleted the session and logged the user out on *any* failed renewal call. This PR keeps that fix for transient failures and, per review, reinstates deletion specifically for 401s (see above).
- **Known pre-existing issue, not touched by this PR** (flagging per review so it's on record): `check_and_maybe_renew` reads the session under a lock, awaits the network call, then re-acquires the lock to write the result. If a logout happens in that window, the in-flight renewal can resurrect the just-logged-out session (both the in-memory state and the file) once it completes. This read-lock → await → write-lock shape predates this PR (the original `start_token_refresh` had the same structure) — it's a candidate for a follow-up, not something this PR expands scope to fix.

Do not merge — opening for review.
