### PR TITLE
test: use filesystem-safe temp dir names in sync runner tests

### DIFF
--- a/src/sync/runner.rs
+++ b/src/sync/runner.rs
@@ -392,6 +392,7 @@ async fn refresh_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn payment_required_reason_has_stable_wire_value() {
@@ -496,13 +497,8 @@ mod tests {
 
     #[test]
     fn file_age_secs_reports_recent_write_as_near_zero() {
-        let dir = std::env::temp_dir().join(format!(
-            "cookcli-runner-test-{}-{:?}",
-            std::process::id(),
-            Instant::now()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("session.json");
+        let path = temp_session_path("file-age");
+        let dir = path.parent().unwrap().to_path_buf();
         std::fs::write(&path, "{}").unwrap();
 
         let age = file_age_secs(&path).expect("metadata should be readable");
@@ -550,11 +546,17 @@ mod tests {
         }
     }
 
+    /// A fresh temp directory for one test, plus the session path inside it.
+    ///
+    /// The suffix has to stay filesystem-safe on every platform: Windows
+    /// rejects `:`, spaces and braces in path components, so no `Debug`
+    /// formatting of clocks here - just a pid and a per-process counter.
     fn temp_session_path(label: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "cookcli-runner-test-{label}-{}-{:?}",
+            "cookcli-runner-test-{label}-{}-{}",
             std::process::id(),
-            Instant::now()
+            COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir.join("session.json")


### PR DESCRIPTION
## Problem

Four `sync::runner` tests fail on `windows-latest` only, blocking CI on `main` ([run 33329650752](https://github.com/cooklang/cookcli/actions/runs/33329650752)):

```
thread 'sync::runner::tests::auth_rejected_clears_the_session_and_deletes_the_file' panicked at src\sync\runner.rs:559:39:
called `Result::unwrap()` on an `Err` value: Os { code: 267, kind: NotADirectory, message: "The directory name is invalid." }
```

- `auth_rejected_clears_the_session_and_deletes_the_file`
- `file_age_secs_reports_recent_write_as_near_zero`
- `successful_renewal_replaces_the_session_and_records_the_time`
- `transient_failure_keeps_the_session_and_the_file`

## Cause

Both test helpers named their temp directory with `{:?}` of an `Instant`:

```
cookcli-runner-test-15720-Instant { tv_sec: 131419, tv_nsec: 294253417 }
```

That path component contains `:`, spaces and braces. Legal on Unix, illegal on Windows — so `create_dir_all` could never succeed there. Test fixtures only; nothing in the production code path was wrong.

## Fix

Build the unique suffix from the pid plus a per-process `AtomicUsize` counter — filesystem-safe everywhere, and still collision-free across parallel test threads and concurrent test binaries.

`file_age_secs_reports_recent_write_as_near_zero` had duplicated the same bad snippet inline, so it now shares the `temp_session_path` helper instead of carrying its own copy.

## Verification

`cargo fmt`, `cargo clippy --all-targets` clean, full `cargo test` suite green locally. Local runs are macOS, where these tests already passed — the Windows job on this PR is the real confirmation.

https://claude.ai/code/session_01V5XkBXdf8QdEho9QWQdFC8