### PR TITLE
fix(build): wire resolved --lang to <html lang> attribute

### DIFF
--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -28,7 +28,6 @@ impl Tr {
         crate::web::i18n::LOCALES.lookup_with_args(&self.lang, key, &args)
     }
 
-    #[cfg(feature = "server")]
     pub fn lang_string(&self) -> String {
         self.lang.to_string()
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="">
+<html lang="{{ tr.lang_string() }}" class="">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -98,6 +98,45 @@ fn build_lang_arg_changes_ui_locale() {
 }
 
 #[test]
+fn build_lang_arg_sets_html_lang_attribute() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+            "--lang",
+            "fr-FR",
+        ])
+        .assert()
+        .success();
+
+    // The resolved build language must be reflected on <html lang>, not left
+    // hardcoded to en. Screen readers and search engines rely on it.
+    let index = std::fs::read_to_string(out.join("index.html")).unwrap();
+    assert!(
+        index.contains(r#"<html lang="fr-FR""#),
+        "index should carry lang=\"fr-FR\" on <html> under --lang fr-FR"
+    );
+    assert!(
+        !index.contains(r#"<html lang="en""#),
+        "index must not keep the hardcoded lang=\"en\""
+    );
+
+    let recipe = std::fs::read_to_string(out.join("recipe/Risotto.html")).unwrap();
+    assert!(
+        recipe.contains(r#"<html lang="fr-FR""#),
+        "recipe page should carry lang=\"fr-FR\" on <html> under --lang fr-FR"
+    );
+}
+
+#[test]
 fn build_lang_arg_rejects_unsupported() {
     let tmp = TempDir::new().unwrap();
     let out = tmp.path().join("_site");


### PR DESCRIPTION
`cook build --lang fr-FR` renders French UI (Recettes, Rechercher) and a `/fr/` sitemap, but every page shipped `lang="en"` on `<html>` — screen readers picked the wrong voice and search engines got a contradictory language signal.

## Fix

`templates/base.html` now binds `<html lang="{{ tr.lang_string() }}">` to the `Tr` locale already threaded through every template — the same `LanguageIdentifier` `--lang` resolves.

`Tr::lang_string` was `#[cfg(feature = "server")]`; ungated so the static-site build (no `server` feature) reads it too. The server build already used it in `preferences.html`.

## Verify

```
cook build web dist --lang fr-FR
grep -o '<html[^>]*lang="[^"]*"' dist/index.html dist/recipe/Risotto.html
# → lang="fr-FR" on both (was lang="en")
```

## Test plan

- [x] Added `build_lang_arg_sets_html_lang_attribute` — asserts `lang="fr-FR"` on index + recipe pages, absence of hardcoded `lang="en"`
- [x] Full suite green (`cargo test`), `cargo clippy` clean, `cargo fmt`

Closes #470