### PR TITLE
chore(deps): bump fluent to 0.17 and fluent-templates to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -1503,16 +1503,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
+ "rustc-hash",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -1528,22 +1528,22 @@ dependencies = [
 
 [[package]]
 name = "fluent-syntax"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "fluent-template-macros"
-version = "0.10.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86ebacac709a063f57ee83d37c451d60dc873554f9bd828531fd1ec43209c80"
+checksum = "3f17b7ed5b7108d57ca049e1fa7583d4fadbb71ef0e47a72dc847c1e704f37fb"
 dependencies = [
  "flume",
  "ignore",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-templates"
-version = "0.10.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f339cc149c01ba2f7b0feba2acde6dd6e4a48472daffe2ddfdd6073e564c60b3"
+checksum = "97fc3bfc211d9a9210bd7ccba798da57148e5b02c62b98b6cef09d7228f2f232"
 dependencies = [
  "fluent-bundle",
  "fluent-langneg",
@@ -1564,8 +1564,7 @@ dependencies = [
  "ignore",
  "intl-memoizer",
  "log",
- "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "unic-langid",
 ]
 
@@ -3030,7 +3029,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.20",
@@ -3052,7 +3051,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3365,12 +3364,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
@@ -3586,15 +3579,6 @@ dependencies = [
  "fastrand",
  "tempfile",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.2.2",
 ]
 
 [[package]]
@@ -4663,7 +4647,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.3",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,9 @@ cooklang-reports = { version = "0.5.1" }
 cookcli-core = { version = "0.35.0", path = "crates/core" }
 directories = "6"
 flate2 = "1"
-fluent = "0.16"
+fluent = "0.17"
 futures-util = { version = "0.3", optional = true }
-fluent-templates = "0.10"
+fluent-templates = "0.15"
 mime_guess = "2.0"
 notify = { version = "8", optional = true }
 notify-debouncer-full = { version = "0.7", optional = true }

--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -24,7 +24,10 @@ impl Tr {
     /// Translate a pluralized message. Passes `$count` as a number so Fluent
     /// plural selectors (`[one]` / `[other]`, etc.) resolve correctly.
     pub fn tn(&self, key: &str, count: &usize) -> String {
-        let args = std::collections::HashMap::from([("count", fluent::FluentValue::from(count))]);
+        let args = std::collections::HashMap::from([(
+            std::borrow::Cow::Borrowed("count"),
+            fluent::FluentValue::from(count),
+        )]);
         crate::web::i18n::LOCALES.lookup_with_args(&self.lang, key, &args)
     }
 


### PR DESCRIPTION
Combines Dependabot's #478 (fluent 0.16 → 0.17) and #479 (fluent-templates 0.10 → 0.15), which both failed CI on their own.

The two have to move together: fluent-templates 0.15 re-exports fluent 0.17, so bumping either alone makes `FluentValue` a different type from the one the loader expects — that's the `E0308: mismatched types` both PRs hit.

**Code change:** `Loader::lookup_with_args` now takes `HashMap<Cow<'static, str>, FluentValue>` rather than `HashMap<&str, _>`, so the plural-args map in `Tr::tn` builds a `Cow` key.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace` all pass. The `recipes_count_pluralizes` test covers the changed line.

Closes #478
Closes #479

https://claude.ai/code/session_014YnqenVFH8YVjky9To3pLF