### PR TITLE
chore(deps): bump axum from 0.7 to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,17 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_axum"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
-dependencies = [
- "askama",
- "axum-core",
- "http",
-]
-
-[[package]]
 name = "askama_derive"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,14 +286,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -317,8 +306,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -334,11 +322,31 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "http",
@@ -347,7 +355,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "serde_core",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -631,9 +639,9 @@ dependencies = [
  "anstream",
  "anyhow",
  "askama",
- "askama_axum",
  "assert_cmd",
  "axum",
+ "axum-extra",
  "base64 0.23.1",
  "camino",
  "chrono",
@@ -2505,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -3115,8 +3123,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3141,12 +3159,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4306,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -4641,20 +4678,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.7",
+ "rand 0.9.5",
  "sha1",
- "thiserror 1.0.69",
- "utf-8",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["self-update", "sync", "server", "import", "lsp"]
 # `cook server` - the axum web UI. Pulls in the whole HTTP server stack.
 server = [
     "dep:axum",
-    "dep:askama_axum",
+    "dep:axum-extra",
     "dep:tower",
     "dep:tower-http",
     "dep:notify",
@@ -61,8 +61,8 @@ accept-language = "3"
 anstream = "1.0"
 anyhow = "1"
 askama = { version = "0.12", features = ["serde-json"] }
-askama_axum = { version = "0.4", optional = true }
-axum = { version = "0.7", features = ["ws"], optional = true }
+axum = { version = "0.8", features = ["ws"], optional = true }
+axum-extra = { version = "0.10", optional = true }
 camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,7 +79,7 @@ Response:
 }
 ```
 
-### `GET /api/recipes/*path`
+### `GET /api/recipes/{*path}`
 
 Read one parsed recipe
 
@@ -160,7 +160,7 @@ Response:
 }
 ```
 
-### `GET /api/recipes/raw/*path`
+### `GET /api/recipes/raw/{*path}`
 
 Read the unparsed Cooklang source
 
@@ -183,7 +183,7 @@ Crack the @eggs{3} into a blender, then add the @flour{125%g},
 @milk{250%ml} and @sea salt{pinch}, and blitz until smooth.
 ```
 
-### `PUT /api/recipes/*path`
+### `PUT /api/recipes/{*path}`
 
 Create or overwrite a recipe
 
@@ -212,7 +212,7 @@ Response:
 }
 ```
 
-### `DELETE /api/recipes/*path`
+### `DELETE /api/recipes/{*path}`
 
 Delete a recipe file
 
@@ -231,11 +231,11 @@ Response:
 }
 ```
 
-### `GET /api/static/*path`
+### `GET /api/static/{*path}`
 
 Fetch a recipe asset
 
-Serves files straight from the recipe directory — this is where recipe images live. The `image` field returned by `GET /api/recipes/*path` is already a URL into this route.
+Serves files straight from the recipe directory — this is where recipe images live. The `image` field returned by `GET /api/recipes/{*path}` is already a URL into this route.
 
 | Name | In | Type | Required | Description |
 |------|----|------|----------|-------------|
@@ -260,7 +260,7 @@ Response:
 ]
 ```
 
-### `GET /api/menus/*path`
+### `GET /api/menus/{*path}`
 
 Read one menu
 
@@ -749,7 +749,7 @@ Response:
 }
 ```
 
-### `PUT /api/pantry/:section/:name`
+### `PUT /api/pantry/{section}/{name}`
 
 Update an item
 
@@ -779,7 +779,7 @@ Response:
 }
 ```
 
-### `DELETE /api/pantry/:section/:name`
+### `DELETE /api/pantry/{section}/{name}`
 
 Remove an item
 
@@ -844,7 +844,7 @@ Collection-wide queries.
 
 Full-text recipe search
 
-Matches against recipe names and content. Menus are searched alongside recipes. `q` is required: omitting it entirely returns a plain-text 400 from axum's query deserializer (`Failed to deserialize query string: missing field q`), not the page's usual JSON error envelope — the same shape as the `scale` parameter's failure mode on `GET /api/recipes/*path`. A present but empty `q=` is not rejected, though: it matches everything and returns the whole collection.
+Matches against recipe names and content. Menus are searched alongside recipes. `q` is required: omitting it entirely returns a plain-text 400 from axum's query deserializer (`Failed to deserialize query string: missing field q`), not the page's usual JSON error envelope — the same shape as the `scale` parameter's failure mode on `GET /api/recipes/{*path}`. A present but empty `q=` is not rejected, though: it matches everything and returns the whole collection.
 
 | Name | In | Type | Required | Description |
 |------|----|------|----------|-------------|

--- a/src/server/lsp_bridge.rs
+++ b/src/server/lsp_bridge.rs
@@ -183,7 +183,7 @@ async fn run_bridge(
     // Task: Send messages from channel to WebSocket
     let mut ws_send_handle = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
-            if let Err(e) = ws_sender.send(Message::Text(msg)).await {
+            if let Err(e) = ws_sender.send(Message::Text(msg.into())).await {
                 error!("Error sending to WebSocket: {}", e);
                 return;
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -179,7 +179,7 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
     let inner = Router::new()
         .nest("/api", api(&state)?)
         .merge(ui::ui())
-        .route("/static/*file", get(serve_static))
+        .route("/static/{*file}", get(serve_static))
         .nest_service("/api/static", ServeDir::new(&state.base_path));
 
     let app = if state.url_prefix.is_empty() {
@@ -465,23 +465,23 @@ fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
         .route("/pantry/expiring", get(handlers::get_expiring))
         .route("/pantry/depleted", get(handlers::get_depleted))
         .route(
-            "/pantry/:section/:name",
+            "/pantry/{section}/{name}",
             axum::routing::delete(handlers::remove_pantry_item),
         )
         .route(
-            "/pantry/:section/:name",
+            "/pantry/{section}/{name}",
             axum::routing::put(handlers::update_pantry_item),
         )
         .route("/recipes", get(handlers::all_recipes))
-        .route("/recipes/raw/*path", get(handlers::recipe_raw)) // More specific route must come first
+        .route("/recipes/raw/{*path}", get(handlers::recipe_raw)) // More specific route must come first
         .route(
-            "/recipes/*path",
+            "/recipes/{*path}",
             get(handlers::recipe)
                 .put(handlers::recipe_save)
                 .delete(handlers::recipe_delete),
         )
         .route("/menus", get(handlers::list_menus))
-        .route("/menus/*path", get(handlers::get_menu))
+        .route("/menus/{*path}", get(handlers::get_menu))
         .route("/search", get(handlers::search))
         .route("/stats", get(handlers::stats))
         .route("/reload", get(handlers::reload).post(handlers::reload))

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -2,12 +2,13 @@ use crate::server::AppState;
 use crate::web::language::FeatureFlags;
 use crate::web::templates::*;
 use axum::{
-    extract::{Extension, Host, Path, Query, State},
+    extract::{Extension, Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::get,
     Form, Router,
 };
+use axum_extra::extract::Host;
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use std::sync::Arc;
@@ -34,9 +35,9 @@ fn error_page(
 pub fn ui() -> Router<Arc<AppState>> {
     Router::new()
         .route("/", get(recipes_page))
-        .route("/directory/*path", get(recipes_directory))
-        .route("/recipe/*path", get(recipe_page))
-        .route("/edit/*path", get(edit_page))
+        .route("/directory/{*path}", get(recipes_directory))
+        .route("/recipe/{*path}", get(recipe_page))
+        .route("/edit/{*path}", get(edit_page))
         .route("/new", get(new_page).post(create_recipe))
         .route("/shopping-list", get(shopping_list_page))
         .route("/pantry", get(pantry_page))
@@ -222,7 +223,7 @@ async fn new_page(
     Extension(lang): Extension<LanguageIdentifier>,
     Extension(features): Extension<FeatureFlags>,
     Query(query): Query<NewPageQuery>,
-) -> impl askama_axum::IntoResponse {
+) -> impl IntoResponse {
     crate::web::templates::NewTemplate {
         active: "recipes".to_string(),
         tr: Tr::new(lang),
@@ -459,7 +460,7 @@ async fn shopping_list_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
     Extension(features): Extension<FeatureFlags>,
-) -> impl askama_axum::IntoResponse {
+) -> impl IntoResponse {
     ShoppingListTemplate {
         active: "shopping".to_string(),
         tr: Tr::new(lang),
@@ -474,7 +475,7 @@ async fn pantry_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
     Extension(features): Extension<FeatureFlags>,
-) -> Result<impl askama_axum::IntoResponse, StatusCode> {
+) -> Result<impl IntoResponse, StatusCode> {
     // Load pantry configuration
     let pantry_path = state.pantry_path.as_ref();
 
@@ -524,7 +525,7 @@ async fn preferences_page(
     State(state): State<Arc<AppState>>,
     Extension(lang): Extension<LanguageIdentifier>,
     Extension(features): Extension<FeatureFlags>,
-) -> impl askama_axum::IntoResponse {
+) -> impl IntoResponse {
     #[cfg(feature = "sync")]
     let (sync_logged_in, sync_email, sync_syncing, _sync_reason) = state.sync_status().await;
     #[cfg(not(feature = "sync"))]
@@ -561,7 +562,7 @@ async fn api_docs_page(
     Host(host): Host,
     Extension(lang): Extension<LanguageIdentifier>,
     Extension(features): Extension<FeatureFlags>,
-) -> impl askama_axum::IntoResponse {
+) -> impl IntoResponse {
     ApiDocsTemplate {
         active: "preferences".to_string(),
         // Rendered so integrators can copy a working URL rather than a

--- a/src/web/api_docs.rs
+++ b/src/web/api_docs.rs
@@ -11,7 +11,7 @@
 //! itself.
 //!
 //! The check compares paths only; a wrong *method* on a real path is not
-//! caught. `POST /api/recipes/*path` — which does not exist — would pass
+//! caught. `POST /api/recipes/{*path}` — which does not exist — would pass
 //! `no_documented_path_is_stale` cleanly, because axum registers verbs as
 //! `.route(path, get(h).put(h).delete(h))` and the textual extractor never
 //! sees them.
@@ -210,7 +210,7 @@ fn recipes() -> ApiSection {
             ),
             ep(
                 "GET",
-                "/api/recipes/*path",
+                "/api/recipes/{*path}",
                 "Read one parsed recipe",
                 "Parses the recipe and returns its ingredients, cookware, timers and steps. \
                  `grouped_ingredients` aggregates repeated ingredients and indexes back into \
@@ -293,7 +293,7 @@ fn recipes() -> ApiSection {
             ),
             ep(
                 "GET",
-                "/api/recipes/raw/*path",
+                "/api/recipes/raw/{*path}",
                 "Read the unparsed Cooklang source",
                 "Returns the file's text verbatim with content type `text/plain`, including \
                  YAML frontmatter. The `.cook` and `.menu` extensions are optional in the path — \
@@ -317,7 +317,7 @@ Crack the @eggs{3} into a blender, then add the @flour{125%g},
             ),
             ep(
                 "PUT",
-                "/api/recipes/*path",
+                "/api/recipes/{*path}",
                 "Create or overwrite a recipe",
                 "The request body is the raw Cooklang source as `text/plain` — not JSON. \
                  Writes are atomic (temp file plus rename). If the file does not exist yet, \
@@ -350,7 +350,7 @@ Mix the @flour{200%g} and @water{120%ml}.
             ),
             ep(
                 "DELETE",
-                "/api/recipes/*path",
+                "/api/recipes/{*path}",
                 "Delete a recipe file",
                 "Permanently removes the file from disk. There is no undo and no trash.",
             )
@@ -370,10 +370,10 @@ Mix the @flour{200%g} and @water{120%ml}.
             ),
             ep(
                 "GET",
-                "/api/static/*path",
+                "/api/static/{*path}",
                 "Fetch a recipe asset",
                 "Serves files straight from the recipe directory — this is where recipe images \
-                 live. The `image` field returned by `GET /api/recipes/*path` is already a URL \
+                 live. The `image` field returned by `GET /api/recipes/{*path}` is already a URL \
                  into this route.",
             )
             .params(vec![path_param(
@@ -409,7 +409,7 @@ fn menus() -> ApiSection {
             ),
             ep(
                 "GET",
-                "/api/menus/*path",
+                "/api/menus/{*path}",
                 "Read one menu",
                 "Sections correspond to days; a `date` is extracted when the section name \
                  contains one in parentheses, e.g. `Day 1 (2026-03-04)` — the seed menus don't \
@@ -1084,7 +1084,7 @@ fn pantry() -> ApiSection {
             ),
             ep(
                 "PUT",
-                "/api/pantry/:section/:name",
+                "/api/pantry/{section}/{name}",
                 "Update an item",
                 "Only the fields present in the body are changed; omitted fields keep their \
                  current values. Returns 404 if the section does not exist. A name that \
@@ -1116,7 +1116,7 @@ fn pantry() -> ApiSection {
             ),
             ep(
                 "DELETE",
-                "/api/pantry/:section/:name",
+                "/api/pantry/{section}/{name}",
                 "Remove an item",
                 "The section is deleted too if it becomes empty. Returns 404 if the section \
                  does not exist, but — like `PUT` — responds `200` with a success message even \
@@ -1204,7 +1204,7 @@ fn search_and_stats() -> ApiSection {
                  recipes. `q` is required: omitting it entirely returns a plain-text 400 from \
                  axum's query deserializer (`Failed to deserialize query string: missing field \
                  q`), not the page's usual JSON error envelope — the same shape as the \
-                 `scale` parameter's failure mode on `GET /api/recipes/*path`. A present but \
+                 `scale` parameter's failure mode on `GET /api/recipes/{*path}`. A present but \
                  empty `q=` is not rejected, though: it matches everything and returns the \
                  whole collection.",
             )
@@ -1515,7 +1515,7 @@ mod tests {
 
     const FIXTURE: &str = r#"
 fn serve_static() {
-    .route("/static/*file", get(serve_static))
+    .route("/static/{*file}", get(serve_static))
 }
 
 fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
@@ -1525,9 +1525,9 @@ fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
             "/shopping_list/items",
             get(handlers::get_shopping_list_items),
         )
-        .route("/pantry/:section/:name", axum::routing::delete(h))
-        .route("/pantry/:section/:name", axum::routing::put(h))
-        .route("/recipes/*path", get(h).put(h).delete(h));
+        .route("/pantry/{section}/{name}", axum::routing::delete(h))
+        .route("/pantry/{section}/{name}", axum::routing::put(h))
+        .route("/recipes/{*path}", get(h).put(h).delete(h));
 
     #[cfg(feature = "sync")]
     let router = router.route("/sync/status", get(handlers::sync_status));
@@ -1540,25 +1540,25 @@ fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
     fn extracts_api_routes_with_prefix() {
         let paths = router_paths(FIXTURE);
         assert!(paths.contains("/api/shopping_list"));
-        assert!(paths.contains("/api/recipes/*path"));
+        assert!(paths.contains("/api/recipes/{*path}"));
     }
 
     #[test]
     fn ignores_routes_defined_before_the_api_fn() {
         let paths = router_paths(FIXTURE);
         assert!(
-            !paths.contains("/api/static/*file"),
-            "the /static/*file route lives outside api() and must not be collected"
+            !paths.contains("/api/static/{*file}"),
+            "the /static/{{*file}} route lives outside api() and must not be collected"
         );
     }
 
     #[test]
     fn deduplicates_paths_registered_once_per_method() {
         let paths = router_paths(FIXTURE);
-        assert!(paths.contains("/api/pantry/:section/:name"));
+        assert!(paths.contains("/api/pantry/{section}/{name}"));
         // 5 distinct paths in the fixture: shopping_list, shopping_list/items
-        // (wrapped `.route(` call), pantry/:section/:name (registered twice,
-        // for DELETE and PUT), recipes/*path, sync/status.
+        // (wrapped `.route(` call), pantry/{section}/{name} (registered twice,
+        // for DELETE and PUT), recipes/{*path}, sync/status.
         assert_eq!(paths.len(), 5, "expected 5 distinct paths, got {paths:?}");
     }
 
@@ -1591,8 +1591,8 @@ fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
             "/api/shopping_list/add_menu",
             "/api/shopping_list/remove",
             "/api/shopping_list/uncheck",
-            "/api/pantry/:section/:name",
-            "/api/recipes/*path",
+            "/api/pantry/{section}/{name}",
+            "/api/recipes/{*path}",
         ] {
             assert!(
                 paths.contains(expected),
@@ -1601,7 +1601,7 @@ fn api(_state: &AppState) -> Result<Router<Arc<AppState>>> {
         }
 
         assert!(
-            !paths.contains("/api/static/*file"),
+            !paths.contains("/api/static/{*file}"),
             "the outer router's static route must not be collected"
         );
         assert!(
@@ -1660,7 +1660,7 @@ fn sync_router() -> Router { Router::new().route("/sync/status", get(h)) }
     /// Paths that are documented but are not registered via `.route(...)`
     /// inside `api()`. Currently just the asset service, which is mounted
     /// with `.nest_service("/api/static", ...)` on the outer router.
-    const NOT_ROUTER_REGISTERED: &[&str] = &["/api/static/*path"];
+    const NOT_ROUTER_REGISTERED: &[&str] = &["/api/static/{*path}"];
 
     fn documented_paths() -> BTreeSet<String> {
         sections()
@@ -1735,7 +1735,7 @@ fn sync_router() -> Router { Router::new().route("/sync/status", get(h)) }
     /// The page renders prose through the `inline_code` filter, which handles
     /// backtick spans and nothing else. Markdown emphasis written in a
     /// description reaches the reader as literal asterisks or underscores —
-    /// caught once in a `PUT /api/pantry/:section/:name` description that
+    /// caught once in a `PUT /api/pantry/{section}/{name}` description that
     /// shipped `**not**` to the page. Automated output checks missed it
     /// because the markup is valid HTML; only looking at the page revealed it.
     #[test]

--- a/src/web/templates.rs
+++ b/src/web/templates.rs
@@ -721,7 +721,7 @@ pub struct ParamDoc {
 #[cfg(feature = "server")]
 pub struct EndpointDoc {
     pub method: String,
-    /// Path in axum route syntax, e.g. "/api/pantry/:section/:name".
+    /// Path in axum route syntax, e.g. "/api/pantry/{section}/{name}".
     pub path: String,
     pub summary: String,
     /// Longer prose. Empty string means "no extra detail".
@@ -801,3 +801,58 @@ pub struct ApiDocsTemplate {
     pub repo_url: Option<String>,
     pub features: FeatureFlags,
 }
+
+/// Askama's axum integration lived in the `askama_axum` crate, which was
+/// deprecated and never updated for axum 0.8. It provided a blanket
+/// `IntoResponse` for every `Template`; a blanket impl is not available to us
+/// (both traits are foreign), so each response template opts in explicitly.
+#[cfg(feature = "server")]
+macro_rules! impl_into_response {
+    ($($t:ty),+ $(,)?) => {
+        $(impl axum::response::IntoResponse for $t {
+            fn into_response(self) -> axum::response::Response {
+                match askama::Template::render(&self) {
+                    Ok(body) => axum::response::Html(body).into_response(),
+                    Err(err) => {
+                        tracing::error!("failed to render template: {err}");
+                        (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "Template rendering failed",
+                        )
+                            .into_response()
+                    }
+                }
+            }
+        })+
+    };
+}
+
+#[cfg(feature = "server")]
+impl_into_response!(
+    ErrorTemplate,
+    RecipesTemplate,
+    RecipeTemplate,
+    MenuTemplate,
+    ShoppingListTemplate,
+    PreferencesTemplate,
+    PantryTemplate,
+    EditTemplate,
+    NewTemplate,
+    ApiDocsTemplate,
+);
+
+/// The two large templates are handed around boxed, and `Box<T>` is not
+/// itself a `Template`.
+#[cfg(feature = "server")]
+macro_rules! impl_into_response_boxed {
+    ($($t:ty),+ $(,)?) => {
+        $(impl axum::response::IntoResponse for Box<$t> {
+            fn into_response(self) -> axum::response::Response {
+                (*self).into_response()
+            }
+        })+
+    };
+}
+
+#[cfg(feature = "server")]
+impl_into_response_boxed!(RecipeTemplate, MenuTemplate);

--- a/tests/e2e/api-docs.spec.ts
+++ b/tests/e2e/api-docs.spec.ts
@@ -36,7 +36,7 @@ test.describe('API documentation page', () => {
   test('documents endpoints with method badges and paths', async ({ page }) => {
     await helpers.navigateTo('/api-docs');
     await expect(page.getByText('/api/shopping_list/items').first()).toBeVisible();
-    await expect(page.locator('#pantry').getByText('/api/pantry/:section/:name').first()).toBeVisible();
+    await expect(page.locator('#pantry').getByText('/api/pantry/{section}/{name}').first()).toBeVisible();
 
     // Every verb the API uses should appear as a badge somewhere on the page.
     for (const method of ['GET', 'POST', 'PUT', 'DELETE']) {


### PR DESCRIPTION
Replaces Dependabot's #477, which failed CI — axum 0.8 has four breaking changes this codebase hits.

### What changed

| Break | Fix |
|---|---|
| Path syntax: `/:param` → `/{param}`, `/*rest` → `/{*rest}` | Updated the router, `web::api_docs` (its paths are asserted against the real router by `no_documented_path_is_stale`), and the regenerated `docs/api.md` |
| `axum::extract::Host` removed | Now `axum_extra::extract::Host`; `axum-extra` joins the `server` feature |
| `askama_axum` deprecated, never updated for axum 0.8 | It only existed for its blanket `IntoResponse for T: Template`. A blanket impl isn't ours to write (both traits foreign), so response templates opt in via a macro — and a render failure now logs + 500s instead of panicking |
| `Message::Text` carries `Utf8Bytes`, not `String` | LSP bridge converts on send; receive side unchanged (`Utf8Bytes` derefs to `str`) |

`docs/api.md` now documents `/api/pantry/{section}/{name}` and `/api/recipes/{*path}` — a cosmetic change to the published reference, following the router.

### Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and the `--no-default-features` build + test all pass.

The interesting risks here are runtime, not compile-time, so I ran the server against `./seed` and checked:

- **Router builds** — axum 0.8 rejects conflicting wildcards at registration; `/api/recipes/raw/{*path}` still shadows `/api/recipes/{*path}` (both return 200 for the right file).
- **Every UI and API route answers** — `/`, `/recipe/{*path}`, `/directory/{*path}`, `/edit/{*path}`, `/new`, `/api-docs`, `/shopping-list`, `/pantry`, `/preferences`, `/static/{*file}`, and the `/api` endpoints.
- **Param routes** — `PUT /api/pantry/fridge/butter` updates the item and the change reads back.
- **LSP websocket** — completes a full `initialize` round trip (client text frame in, server text frame out), covering both directions of the `Utf8Bytes` change.
- **CSRF** — the `Host`-based same-origin check still accepts a matching Origin (303 to the editor) and rejects a foreign one.

Closes #477

https://claude.ai/code/session_014YnqenVFH8YVjky9To3pLF