### PR TITLE
fix(build): emit search index as a script so file:// search works

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -77,7 +77,7 @@ Note that only the UI chrome (navigation, headings, labels) is translated — yo
 | `menu/<path>.html` | One page per `.menu` file |
 | `api/static/<path>` | Images alongside recipes (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif`) |
 | `static/css/`, `static/js/` | Compiled CSS, fonts, icons, and the client-side search script |
-| `static/search-index.json` | Search index consumed by `static/js/search.js` |
+| `static/search-index.js` | Search index consumed by `static/js/search.js`, as a script assigning `window.__SEARCH_INDEX__` |
 
 ## What's excluded
 
@@ -116,6 +116,8 @@ Use `--base-url` only if your host serves the site under a fixed subpath and you
 ## Notes
 
 - The generated site has no server dependency — it works fully offline via `file://`.
-- Search runs entirely in the browser by loading `static/search-index.json`.
+- Search runs entirely in the browser by loading `static/search-index.js`. It is a script
+  rather than JSON so that search also works over `file://`, where browsers block
+  `fetch()` between local files.
 - Re-run `cook build web` after editing recipes; the command is idempotent.
 - For a live editing experience, use `cook server` instead.

--- a/docs/build.md
+++ b/docs/build.md
@@ -115,7 +115,9 @@ Use `--base-url` only if your host serves the site under a fixed subpath and you
 
 ## Notes
 
-- The generated site has no server dependency — it works fully offline via `file://`.
+- The generated site has no server dependency: it works fully offline via `file://`.
+  Not with `--base-url` though. That flag makes every asset reference absolute, so from
+  disk the page gets no stylesheet, no icons and no search. Use it only for HTTP hosting.
 - Search runs entirely in the browser by loading `static/search-index.js`. It is a script
   rather than JSON so that search also works over `file://`, where browsers block
   `fetch()` between local files.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -209,9 +209,8 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     let entries = index::build_search_index(&tree);
     let entry_count = entries.len();
     let json = serde_json::to_string(&entries)?;
-    // Emitted as a script assigning a global, not as JSON: browsers give every
-    // file:// resource its own opaque origin, so search.js cannot fetch() the
-    // index when the site is opened from disk. A classic <script> can load it.
+    // A script assigning a global, not JSON: file:// documents are opaque
+    // origins, so search.js cannot fetch the index from disk. See docs/build.md.
     let script = format!("window.__SEARCH_INDEX__ = {json};\n");
     writer::write_bytes(
         &output,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -209,10 +209,14 @@ fn run_web(ctx: &Context, args: WebBuildArgs) -> Result<()> {
     let entries = index::build_search_index(&tree);
     let entry_count = entries.len();
     let json = serde_json::to_string(&entries)?;
+    // Emitted as a script assigning a global, not as JSON: browsers give every
+    // file:// resource its own opaque origin, so search.js cannot fetch() the
+    // index when the site is opened from disk. A classic <script> can load it.
+    let script = format!("window.__SEARCH_INDEX__ = {json};\n");
     writer::write_bytes(
         &output,
-        camino::Utf8Path::new("static/search-index.json"),
-        json.as_bytes(),
+        camino::Utf8Path::new("static/search-index.js"),
+        script.as_bytes(),
     )?;
 
     // The URL was already validated near the top of run_web.

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -7,11 +7,9 @@
   var indexPromise = null;
   var selectedIndex = -1;
 
-  // The index is loaded by injecting a classic <script> rather than fetching
-  // JSON. Browsers give every file:// resource its own opaque origin, which
-  // blocks fetch() but not classic script tags, so this is what keeps search
-  // working when the generated site is opened from disk. It must stay a
-  // classic script: module scripts are CORS-gated and fail like fetch does.
+  // Loaded as a classic <script>, never fetched: file:// documents are opaque
+  // origins, so a fetch is blocked and search returns nothing from disk. Must
+  // stay classic — module scripts are CORS-gated and fail the same way.
   function loadIndex() {
     if (indexPromise) return indexPromise;
     indexPromise = new Promise(function (resolve) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -4,22 +4,29 @@
   var results = document.getElementById("search-results");
   if (!input || !results) return;
 
-  var index = null;
+  var indexPromise = null;
   var selectedIndex = -1;
 
+  // The index is loaded by injecting a classic <script> rather than fetching
+  // JSON. Browsers give every file:// resource its own opaque origin, which
+  // blocks fetch() but not classic script tags, so this is what keeps search
+  // working when the generated site is opened from disk. It must stay a
+  // classic script: module scripts are CORS-gated and fail like fetch does.
   function loadIndex() {
-    if (index !== null) return Promise.resolve(index);
-    return fetch(prefix + "/static/search-index.json")
-      .then(function (r) { return r.json(); })
-      .then(function (data) {
-        index = data;
-        return data;
-      })
-      .catch(function (e) {
-        console.error("search-index load failed", e);
-        index = [];
-        return index;
-      });
+    if (indexPromise) return indexPromise;
+    indexPromise = new Promise(function (resolve) {
+      var script = document.createElement("script");
+      script.src = prefix + "/static/search-index.js";
+      script.onload = function () {
+        resolve(window.__SEARCH_INDEX__ || []);
+      };
+      script.onerror = function () {
+        console.error("search-index load failed");
+        resolve([]);
+      };
+      document.head.appendChild(script);
+    });
+    return indexPromise;
   }
 
   function score(entry, q) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -16,10 +16,13 @@
       var script = document.createElement("script");
       script.src = prefix + "/static/search-index.js";
       script.onload = function () {
+        if (!window.__SEARCH_INDEX__) {
+          console.error("search-index loaded but set no index: " + script.src);
+        }
         resolve(window.__SEARCH_INDEX__ || []);
       };
       script.onerror = function () {
-        console.error("search-index load failed");
+        console.error("search-index failed to load: " + script.src);
         resolve([]);
       };
       document.head.appendChild(script);

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -363,11 +363,24 @@ fn build_writes_search_index() {
         .assert()
         .success();
 
-    let idx = out.join("static/search-index.json");
-    assert!(idx.is_file(), "search-index.json should exist");
+    let idx = out.join("static/search-index.js");
+    assert!(idx.is_file(), "search-index.js should exist");
 
-    let json: serde_json::Value =
-        serde_json::from_reader(std::fs::File::open(&idx).unwrap()).unwrap();
+    // The index ships as a classic script assigning a global rather than as
+    // JSON: `fetch()` is blocked between `file://` resources, `<script src>`
+    // is not.
+    let source = std::fs::read_to_string(&idx).unwrap();
+    let payload = source
+        .strip_prefix("window.__SEARCH_INDEX__ = ")
+        .and_then(|s| s.strip_suffix(";\n"))
+        .expect("index should assign window.__SEARCH_INDEX__");
+
+    assert!(
+        !out.join("static/search-index.json").exists(),
+        "search-index.json should no longer be emitted"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(payload).unwrap();
     let arr = json.as_array().expect("index is array");
     assert!(!arr.is_empty(), "index should not be empty for seed");
 
@@ -386,6 +399,51 @@ fn build_writes_search_index() {
         risotto.get("title").and_then(|t| t.as_str()),
         Some("Classic Risotto alla Milanese"),
         "title should be the metadata title; path should be the file stem"
+    );
+}
+
+#[test]
+fn search_js_loads_index_without_fetch() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("_site");
+    let seed = seed_dir();
+
+    Command::cargo_bin("cook")
+        .unwrap()
+        .args([
+            "build",
+            "web",
+            out.to_str().unwrap(),
+            "--base-path",
+            seed.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let js = std::fs::read_to_string(out.join("static/js/search.js")).unwrap();
+
+    // Drop line comments so prose explaining why fetch() is avoided doesn't
+    // satisfy the check below.
+    let code = js
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Stock Chromium and Firefox give every `file://` resource its own opaque
+    // origin, so a runtime `fetch()` for the index is blocked and search
+    // silently returns nothing when the site is opened from disk.
+    assert!(
+        !code.contains("fetch("),
+        "search.js must not fetch the index at runtime (breaks file://)"
+    );
+    assert!(
+        code.contains("search-index.js"),
+        "search.js should load the index as a script"
+    );
+    assert!(
+        code.contains("__SEARCH_INDEX__"),
+        "search.js should read the index from the global the script assigns"
     );
 }
 
@@ -657,7 +715,7 @@ fn build_compress_writes_gzip_variants() {
     for file in [
         "index.html",
         "static/css/output.css",
-        "static/search-index.json",
+        "static/search-index.js",
     ] {
         let gz_path = out.join(format!("{file}.gz"));
         assert!(gz_path.is_file(), "{file}.gz should exist");

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -366,14 +366,16 @@ fn build_writes_search_index() {
     let idx = out.join("static/search-index.js");
     assert!(idx.is_file(), "search-index.js should exist");
 
-    // The index ships as a classic script assigning a global rather than as
-    // JSON: `fetch()` is blocked between `file://` resources, `<script src>`
-    // is not.
     let source = std::fs::read_to_string(&idx).unwrap();
-    let payload = source
-        .strip_prefix("window.__SEARCH_INDEX__ = ")
-        .and_then(|s| s.strip_suffix(";\n"))
-        .expect("index should assign window.__SEARCH_INDEX__");
+    assert!(
+        source.starts_with("window.__SEARCH_INDEX__"),
+        "index should assign window.__SEARCH_INDEX__, got: {:.40}",
+        source
+    );
+    let (_, payload) = source
+        .split_once('=')
+        .expect("index should be an assignment");
+    let payload = payload.trim().trim_end_matches(';');
 
     assert!(
         !out.join("static/search-index.json").exists(),
@@ -403,7 +405,7 @@ fn build_writes_search_index() {
 }
 
 #[test]
-fn search_js_loads_index_without_fetch() {
+fn search_js_loads_index_as_script() {
     let tmp = TempDir::new().unwrap();
     let out = tmp.path().join("_site");
     let seed = seed_dir();
@@ -422,27 +424,12 @@ fn search_js_loads_index_without_fetch() {
 
     let js = std::fs::read_to_string(out.join("static/js/search.js")).unwrap();
 
-    // Drop line comments so prose explaining why fetch() is avoided doesn't
-    // satisfy the check below.
-    let code = js
-        .lines()
-        .filter(|l| !l.trim_start().starts_with("//"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    // Stock Chromium and Firefox give every `file://` resource its own opaque
-    // origin, so a runtime `fetch()` for the index is blocked and search
-    // silently returns nothing when the site is opened from disk.
     assert!(
-        !code.contains("fetch("),
-        "search.js must not fetch the index at runtime (breaks file://)"
+        js.contains("search-index.js"),
+        "search.js should load the index as a script (a fetch breaks file://)"
     );
     assert!(
-        code.contains("search-index.js"),
-        "search.js should load the index as a script"
-    );
-    assert!(
-        code.contains("__SEARCH_INDEX__"),
+        js.contains("__SEARCH_INDEX__"),
         "search.js should read the index from the global the script assigns"
     );
 }

--- a/tests/e2e/static-file-search.spec.ts
+++ b/tests/e2e/static-file-search.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+/**
+ * Search over a site opened straight from disk.
+ *
+ * Browsers give every file:// resource its own opaque origin, so anything the
+ * page fetches at runtime is blocked. The rest of the suite runs against
+ * `cook server`, which takes the /api/search branch and never exercises the
+ * static search path — this spec covers the file:// promise in docs/build.md.
+ */
+test.describe('Static site search over file://', () => {
+  let outDir: string;
+  let indexUrl: string;
+
+  test.beforeAll(() => {
+    outDir = mkdtempSync(path.join(tmpdir(), 'cookcli-static-'));
+    const repoRoot = path.resolve(__dirname, '../..');
+    execFileSync(
+      path.join(repoRoot, 'target/debug/cook'),
+      ['build', 'web', outDir, '--base-path', path.join(repoRoot, 'seed')],
+      { cwd: repoRoot },
+    );
+    indexUrl = pathToFileURL(path.join(outDir, 'index.html')).href;
+  });
+
+  test.afterAll(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('returns results for a recipe title', async ({ page }) => {
+    const failures: string[] = [];
+    page.on('requestfailed', (r) => failures.push(r.url()));
+
+    await page.goto(indexUrl);
+    await page.getByPlaceholder('Search recipes...').fill('Risotto');
+
+    // Risotto also matches two menus that list it as an ingredient; the
+    // title match scores higher and must come first.
+    const results = page.locator('#search-results');
+    await expect(results).toBeVisible();
+    await expect(results.locator('a').first()).toContainText(
+      'Classic Risotto alla Milanese',
+    );
+
+    expect(failures, 'no request should be blocked on file://').toEqual([]);
+  });
+
+  test('result link opens the recipe page', async ({ page }) => {
+    await page.goto(indexUrl);
+    await page.getByPlaceholder('Search recipes...').fill('Risotto');
+    await page.locator('#search-results a').first().click();
+
+    await expect(page).toHaveURL(/Risotto\.html$/);
+    await expect(page.locator('h1')).toContainText('Risotto');
+  });
+
+  test('reports no matches for an absent term', async ({ page }) => {
+    await page.goto(indexUrl);
+    await page.getByPlaceholder('Search recipes...').fill('zzzznotarecipe');
+
+    await expect(page.locator('#search-results')).toContainText('No recipes found');
+  });
+});

--- a/tests/e2e/static-file-search.spec.ts
+++ b/tests/e2e/static-file-search.spec.ts
@@ -60,8 +60,15 @@ test.describe('Static site search over file://', () => {
 
   test('reports no matches for an absent term', async ({ page }) => {
     await page.goto(indexUrl);
-    await page.getByPlaceholder('Search recipes...').fill('zzzznotarecipe');
+    const input = page.getByPlaceholder('Search recipes...');
 
+    // An index that failed to load renders the same empty state, so the
+    // absent-term assertion below only means something once we have seen
+    // a real match come back.
+    await input.fill('Risotto');
+    await expect(page.locator('#search-results a').first()).toBeVisible();
+
+    await input.fill('zzzznotarecipe');
     await expect(page.locator('#search-results')).toContainText('No recipes found');
   });
 });

--- a/tests/e2e/static-file-search.spec.ts
+++ b/tests/e2e/static-file-search.spec.ts
@@ -8,10 +8,9 @@ import { pathToFileURL } from 'url';
 /**
  * Search over a site opened straight from disk.
  *
- * Browsers give every file:// resource its own opaque origin, so anything the
- * page fetches at runtime is blocked. The rest of the suite runs against
- * `cook server`, which takes the /api/search branch and never exercises the
- * static search path — this spec covers the file:// promise in docs/build.md.
+ * The rest of the suite runs against `cook server`, which takes the /api/search
+ * branch and never exercises the static search path. Covers the file:// promise
+ * in docs/build.md.
  */
 test.describe('Static site search over file://', () => {
   let outDir: string;


### PR DESCRIPTION
`cook build web` produces a site the docs call browsable from disk, but search there returns nothing. `static/js/search.js` loads the index with `fetch(prefix + "/static/search-index.json")`. A page opened over `file://` gets the opaque origin `null`, and Chromium blocks the request:

```
Access to fetch at 'file:///…/static/search-index.json' from origin 'null' has been
blocked by CORS policy: Cross origin requests are only supported for protocol schemes:
chrome, chrome-extension, chrome-untrusted, data, http, https, isolated-app.
```

The catch substitutes an empty index, so every query shows "No recipes found". Browsing itself works because page links are relative. Reproduced on 0.34.0 and on current main, with and without `--base-url`.

Launching with `--allow-file-access-from-files` does restore it. That is not something you can ask a reader of a recipe site to do. The index needs a transport that is not origin-gated.

## Fix

`src/build/mod.rs` writes `static/search-index.js` instead of `static/search-index.json`. Same JSON payload, wrapped as `window.__SEARCH_INDEX__ = [...]`. `search.js` appends a classic `<script>` for it and resolves on load or on error. Script elements are not origin-gated, so the index loads from disk.

It has to stay a classic script. Module scripts are CORS-gated and fail over `file://` the same way.

`loadIndex` now caches the in-flight promise rather than the resolved value. The old `index !== null` guard let two quick keystrokes start two loads.

`docs/build.md` records the new artifact. It also fixes the offline claim two lines above it: with `--base-url` every asset reference is absolute, so from disk the page gets no stylesheet and no search. That was already true before this PR.

## Result

Search over a site opened straight from disk, seed recipes, no console errors:

![search results over file://](https://raw.githubusercontent.com/sripwoud/cookcli/ab14ba9f6054cb3d9d16c0a6ebfae2be3c6e311e/search-over-file-url.png)

The first hit opens over `file://` too:

![recipe page over file://](https://raw.githubusercontent.com/sripwoud/cookcli/ab14ba9f6054cb3d9d16c0a6ebfae2be3c6e311e/recipe-page-over-file-url.png)

## Verify

```
cook build web dist --base-path ./seed
chromium file://$PWD/dist/index.html
# search "Risotto" → Classic Risotto alla Milanese, no console error
```

## Test plan

- [x] Added `tests/e2e/static-file-search.spec.ts`, which drives search over `file://`: title match ranks first, the result link opens the recipe page, an absent term reports no matches. Fails 3/3 against the old loader, passes 3/3 here.
- [x] `build_writes_search_index` asserts the global assignment and that `search-index.json` is gone; the gzip test follows the renamed artifact
- [x] Added `search_js_loads_index_as_script`
- [x] `cargo test` green, `cargo clippy` clean, `cargo fmt`
- [x] Rebased on main after the axum 0.8 and fluent 0.17 upgrades

Closes #471
