### PR TITLE
feat(cli): add `cook completions <shell>` for shell completion scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Configuration search order:
 - `seed`: Initialize with example recipes
 - `report`: Generate custom outputs using Jinja2 templates
 - `update`: Self-update the CookCLI binary to the latest version (can be disabled with --no-self-update feature)
+- `completions`: Print a shell completion script (bash, zsh, fish, powershell, elvish) generated from the clap definition
 
 #### Utility Modules
 - `util/`: Shared utilities for parsing, conversion, and output formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +655,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "clap_complete",
  "cookcli-core",
  "cooklang",
  "cooklang-find",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ axum-extra = { version = "0.10", optional = true }
 camino = { version = "1", features = ["serde1"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 base64 = { version = "0.23", optional = true }
 # bundled_units is deliberately NOT enabled: it carries the unit database, and with
 # it Converter::default() silently converts quantities to a "best" unit (e.g.

--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Detailed documentation for each command is available in the [docs/](docs/) direc
 * [Seed](docs/seed.md) - example recipes
 * [Report](docs/report.md) - custom outputs
 * [Pantry](docs/pantry.md) - inventory management and tracking
+* [Completions](docs/completions.md) - shell completion scripts
 
 ## ⚙️ Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ CookCLI is a free, open-source command-line tool for working with [Cooklang](htt
 | [seed](seed.md) | | Initialize with example recipes |
 | [lsp](lsp.md) | | Start the Language Server Protocol server |
 | [update](update.md) | `u` | Update CookCLI to the latest version |
+| [completions](completions.md) | | Generate shell completion scripts |
 
 ## Reference
 

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -1,0 +1,74 @@
+# Completions Command
+
+Generate a shell completion script so your shell can tab-complete `cook` subcommands, aliases and flags.
+
+## Usage
+
+```
+cook completions <SHELL>
+```
+
+The script is printed to stdout. Redirect it into the place your shell loads completions from, or source it from your shell configuration.
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<SHELL>` | One of `bash`, `zsh`, `fish`, `powershell`, `elvish` |
+
+## Installation
+
+### Bash
+
+```bash
+# Linux
+cook completions bash > /etc/bash_completion.d/cook
+
+# macOS (Homebrew bash-completion)
+cook completions bash > "$(brew --prefix)/etc/bash_completion.d/cook"
+
+# Or, without bash-completion, source it from ~/.bashrc
+echo 'source <(cook completions bash)' >> ~/.bashrc
+```
+
+### Zsh
+
+```bash
+# Into a directory on your $fpath, then restart the shell
+cook completions zsh > "${fpath[1]}/_cook"
+
+# Or into a user-owned directory
+mkdir -p ~/.zfunc
+cook completions zsh > ~/.zfunc/_cook
+# ...and in ~/.zshrc, before `compinit`:
+#   fpath=(~/.zfunc $fpath)
+#   autoload -Uz compinit && compinit
+```
+
+### Fish
+
+```bash
+cook completions fish > ~/.config/fish/completions/cook.fish
+```
+
+### PowerShell
+
+```powershell
+# Append to your profile
+cook completions powershell >> $PROFILE
+
+# Or load it on demand
+cook completions powershell | Out-String | Invoke-Expression
+```
+
+### Elvish
+
+```bash
+cook completions elvish >> ~/.config/elvish/rc.elv
+```
+
+## Notes
+
+- The script is generated from the running binary, so it matches that binary exactly. Subcommands compiled out with `--no-default-features` (such as `server`, `import`, `lsp` or `update`) are missing from the script too.
+- Regenerate the script after updating CookCLI so new subcommands and flags show up.
+- Completion is static: it knows subcommands and flags, but does not complete recipe file names or `recipe.cook:2` scaling suffixes.

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,7 +38,7 @@ use crate::lsp;
 use crate::server;
 #[cfg(feature = "self-update")]
 use crate::update;
-use crate::{build, doctor, pantry, recipe, report, search, seed, shopping_list};
+use crate::{build, completions, doctor, pantry, recipe, report, search, seed, shopping_list};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -264,6 +264,21 @@ pub enum Command {
     #[cfg(feature = "sync")]
     #[command(long_about = "Sign out of CookCloud and delete the local session file")]
     Logout(crate::logout::LogoutArgs),
+
+    /// Generate a shell completion script
+    ///
+    /// Prints a completion script for the given shell to stdout. Source it
+    /// from your shell configuration or install it in the shell's completion
+    /// directory to get tab completion for cook subcommands and flags.
+    ///
+    /// Examples:
+    ///   cook completions bash > /usr/local/etc/bash_completion.d/cook
+    ///   cook completions zsh > "${fpath[1]}/_cook"
+    ///   cook completions fish > ~/.config/fish/completions/cook.fish
+    #[command(
+        long_about = "Generate a shell completion script for bash, zsh, fish, PowerShell or elvish"
+    )]
+    Completions(completions::CompletionsArgs),
 
     /// Update CookCLI to the latest version
     ///

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use clap::{Args, CommandFactory};
+use clap_complete::Shell;
+
+use crate::args::CliArgs;
+
+/// Name of the installed binary, which the generated script completes.
+const BIN_NAME: &str = "cook";
+
+#[derive(Debug, Args)]
+pub struct CompletionsArgs {
+    /// Shell to generate the completion script for
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+/// Print a completion script for `shell` to stdout.
+///
+/// The script is generated from the live clap definition, so it always
+/// matches the binary that produced it: subcommands compiled out by a cargo
+/// feature are absent from the script too.
+pub fn run(args: CompletionsArgs) -> Result<()> {
+    let mut cmd = CliArgs::command();
+    // `cmd.get_name()` is the package name ("cookcli"); the script has to
+    // register against the binary users actually type.
+    clap_complete::generate(args.shell, &mut cmd, BIN_NAME, &mut std::io::stdout());
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 // Commands - make them available as public modules
 pub mod build;
+pub mod completions;
 pub mod doctor;
 #[cfg(feature = "import")]
 pub mod import;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ pub use cookcli_core::Context;
 
 // commands
 mod build;
+mod completions;
 mod doctor;
 #[cfg(feature = "import")]
 mod import;
@@ -93,6 +94,7 @@ pub fn main() -> Result<()> {
         Command::Login(args) => login::run(&ctx, args),
         #[cfg(feature = "sync")]
         Command::Logout(args) => logout::run(&ctx, args),
+        Command::Completions(args) => completions::run(args),
         #[cfg(feature = "self-update")]
         Command::Update(args) => update::run(args),
     }

--- a/tests/completions_test.rs
+++ b/tests/completions_test.rs
@@ -1,0 +1,95 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cook() -> Command {
+    Command::cargo_bin("cook").unwrap()
+}
+
+#[test]
+fn completions_bash_prints_a_bash_script() {
+    cook()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match(r"(?m)^\s*complete -F _cook .* cook$").unwrap());
+}
+
+#[test]
+fn completions_zsh_prints_a_zsh_script() {
+    cook()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("#compdef cook\n"));
+}
+
+#[test]
+fn completions_fish_prints_a_fish_script() {
+    cook()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -c cook "));
+}
+
+#[test]
+fn completions_powershell_prints_a_powershell_script() {
+    cook()
+        .args(["completions", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Register-ArgumentCompleter -Native -CommandName 'cook'",
+        ));
+}
+
+#[test]
+fn completions_elvish_prints_an_elvish_script() {
+    cook()
+        .args(["completions", "elvish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "edit:completion:arg-completer[cook]",
+        ));
+}
+
+#[test]
+fn completions_script_covers_subcommands_and_their_flags() {
+    // The script is generated from the live clap definition, so it must know
+    // the subcommands, their aliases and their flags — not just the top level.
+    cook()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("shopping-list"))
+        .stdout(predicate::str::contains(" shopping-list sl "))
+        .stdout(predicate::str::contains("--base-path"));
+}
+
+#[test]
+fn completions_rejects_an_unknown_shell() {
+    cook()
+        .args(["completions", "tcsh"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'tcsh'"));
+}
+
+#[test]
+fn completions_requires_a_shell_argument() {
+    cook()
+        .arg("completions")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("<SHELL>"));
+}
+
+#[test]
+fn completions_is_listed_in_top_level_help() {
+    cook()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("completions"));
+}

--- a/tests/snapshots/snapshot_test__help_output.snap
+++ b/tests/snapshots/snapshot_test__help_output.snap
@@ -15,6 +15,7 @@ Commands:
   report         Generate custom reports from recipes using templates
   doctor         Analyze your recipe collection for issues and improvements
   pantry         Manage and analyze your pantry inventory
+  completions    Generate a shell completion script
   help           Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
Closes #467

## What

New `cook completions <shell>` subcommand that prints a completion script for `bash`, `zsh`, `fish`, `powershell` or `elvish` to stdout, generated with `clap_complete` from the existing `CliArgs` definition.

```
cook completions bash    > /usr/local/etc/bash_completion.d/cook
cook completions zsh     > "${fpath[1]}/_cook"
cook completions fish    > ~/.config/fish/completions/cook.fish
```

- `src/completions.rs` with `CompletionsArgs { shell: clap_complete::Shell }` and `run()`
- `Command::Completions` variant plus match arm in `main.rs`
- `docs/completions.md` with per-shell install instructions, linked from `docs/README.md` and `README.md`
- `tests/completions_test.rs` covering every shell, subcommand/alias/flag coverage, and error cases

## Worth knowing

The binary name is passed explicitly rather than taken from `cmd.get_name()`. That returns the package name `cookcli`, so the first cut registered `complete -F _cookcli cookcli` and would never have fired for `cook`. The tests now assert on the exact registration line so a prefix match can't hide this again.

Generated bash and zsh scripts parse cleanly under `bash -n` / `zsh -n`. The help snapshot gained one line for the new subcommand.

## Open questions from the issue, and what this PR does about them

- **Feature-gated subcommands**: documented in `docs/completions.md` rather than worked around. The script matches whichever binary generated it.
- **Dynamic completion of recipe names**: not included, per the issue's suggestion to ship static first.
- **Bundling scripts in release archives**: not included. Most release targets are cross-compiled on a host that cannot run the resulting binary, so generation would need a separate host build. Better as its own change.

https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh
