### PR TITLE
feat(server): make CORS configuration configurable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ Start the server with [`cook server`](server.md); every endpoint below is served
 
 - **Base URL:** `http://localhost:9080/api`
 - **Authentication:** None. Anyone who can reach the server can read and modify your recipes — think twice before using `--host` on an untrusted network.
-- **CORS:** All origins are allowed, for the methods GET, POST, PUT and DELETE.
+- **CORS:** `GET` is allowed from any origin. A cross-origin request that would modify recipes is refused with `403` unless the server was started with a matching `--cors-origin <ORIGIN>`. Requests with no `Origin` header — `curl` and other non-browser clients — are unaffected. `content-type` is always an allowed request header.
 - **Request size limit:** 1 MB.
 - **Content type:** JSON in and out, except where noted — raw recipe text is `text/plain`.
 
@@ -21,6 +21,7 @@ Every failure returns the same shape, with the status code carrying the meaning:
 ```
 
 - `400` — malformed input: an invalid path, a bad query parameter, or a recipe that failed to parse.
+- `403` — a cross-origin request tried to modify recipes. Start the server with `--cors-origin <ORIGIN>` to allow that origin.
 - `404` — the recipe, menu, or pantry section does not exist, or no pantry file is configured.
 - `500` — the server could not read or write a file.
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -26,6 +26,9 @@ cook server [OPTIONS] [BASE_PATH]
 | `--host [<ADDRESS>]` | Allow connections from external hosts (default: localhost only). Optionally bind to a specific address. |
 | `-p, --port <PORT>` | Port number (default: 9080) |
 | `--open` | Automatically open the web interface in your default browser |
+| `--cors-origin <ORIGIN>` | Origin allowed to make cross-origin browser requests. Repeatable. `*` for any origin (default). |
+| `--cors-allow-credentials` | Allow cross-origin requests to carry cookies and credentials. Requires an explicit `--cors-origin`. |
+| `--no-csrf-check` | Disable same-origin enforcement on requests that modify recipes. |
 
 ## Examples
 
@@ -41,12 +44,21 @@ cook server --port 8080 --open
 
 # Allow access from other devices on the network
 cook server --host
+
+# Let a frontend at localhost:3000 use the full API, including writes
+cook server --cors-origin http://localhost:3000
+
+# Behind a reverse proxy, name the public origin so the UI can still write
+cook server --cors-origin https://cook.example.com
 ```
 
 ## Notes
 
 - By default, only accepts connections from localhost
 - Use `--host` on trusted networks only — recipes become accessible to anyone on the network
+- Cross-origin browser requests can read (`GET`) from any origin by default, but one that would modify recipes is refused with `403`. Naming origins with `--cors-origin` lets those origins write too, so a page you have not listed cannot change your recipes. Requests with no `Origin` header — `curl`, scripts, anything that is not a browser — are unaffected. See [the API reference](api.md).
+- Behind a reverse proxy that rewrites `Host`, pass `--cors-origin` with the public origin (for example `--cors-origin https://cook.example.com`). The same-origin check reads the real `Host` header and ignores `X-Forwarded-Host`, which any client can set freely.
+- `--no-csrf-check` turns that same-origin enforcement off entirely, for both the API and the web UI's new-recipe form. Its former spelling, `--no-cors`, still works.
 - The web interface supports recipe browsing, scaling, search, and shopping list management
 - The UI language is negotiated per request from the browser's `Accept-Language` header — each visitor sees the interface in their own language (supported: `en-US`, `de-DE`, `nl-NL`, `fr-FR`, `es-ES`, `eu-ES`, `sv-SE`). For static sites, see the `--lang` flag of [`cook build web`](build.md#localization).
 - Mobile-friendly responsive layout

--- a/docs/superpowers/plans/2026-09-03-server-cors-config.md
+++ b/docs/superpowers/plans/2026-09-03-server-cors-config.md
@@ -569,6 +569,45 @@ Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
 
 ---
 
+## REVISION (after Task 2-3 code review)
+
+Tasks 1-3 are complete and committed. A code review of Tasks 2-3 found that the
+plan's central premise was wrong: **`allow_methods([GET])` does not block a
+cross-origin `POST`**, because `POST` is a CORS-safelisted method and the
+`Access-Control-Allow-Methods` list is only consulted for non-safelisted ones.
+Verified in a real browser — a cross-origin page wrote to
+`seed/config/pantry.conf` via `POST /api/pantry/add`.
+
+Adding `content-type` to `allow_headers` also removes the accidental protection
+that today's *unset* `allow_headers` provides, so as it stands the new default
+is more permissive than the code it replaces.
+
+The design doc has been corrected (see its "Correction: `allow_methods` cannot
+enforce read-only" and "The cross-origin write guard" sections, commit
+`54f187c`). The remaining tasks are renumbered and rewritten below. Read-only
+is now enforced **server-side** by a write guard; CORS headers describe the
+policy rather than enforce it.
+
+Remaining tasks:
+
+- **Task 4** — review fixes to Tasks 2-3 (help text, smoke tests, polish).
+- **Task 5** — the `--no-cors` → `--no-csrf-check` rename (unchanged from the
+  original Task 4).
+- **Task 6** — the cross-origin write guard (new).
+- **Task 7** — end-to-end tests (the original Task 5, with the `POST`
+  assertions rewritten: a preflight assertion cannot detect the hole, since
+  `AllowOrigin::any()` always answers `*`).
+- **Task 8** — documentation (the original Task 6, with corrected text).
+- **Task 9** — full verification and PR (the original Task 7).
+
+Full task text is supplied to each implementer at dispatch time. The original
+Tasks 4-7 are preserved below for reference; where they conflict with this
+revision, the revision wins.
+
+---
+
+## ORIGINAL TASKS 4-7 (superseded — see REVISION above)
+
 ### Task 4: Rename `--no-cors` to `--no-csrf-check`
 
 **Files:**

--- a/docs/superpowers/plans/2026-09-03-server-cors-config.md
+++ b/docs/superpowers/plans/2026-09-03-server-cors-config.md
@@ -1,0 +1,1183 @@
+# Configurable Server CORS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `cook server`'s CORS policy configurable via `--cors-origin` and `--cors-allow-credentials`, with a safer default (wildcard origin, `GET` only), and rename the misleading `--no-cors` flag to `--no-csrf-check`.
+
+**Architecture:** A new `src/server/cors.rs` turns the two flags into a validated `CorsConfig` value, then into a `tower_http::cors::CorsLayer`. Validation happens in `run()` before the socket binds, so bad flag combinations fail fast. The unrelated `--no-cors` flag (a CSRF check on `POST /new`, not CORS) is renamed with a hidden clap alias for backwards compatibility.
+
+**Tech Stack:** Rust, clap 4 (derive), axum, tower-http 0.7 (`cors` feature), anyhow, reqwest (dev), tempfile + assert_cmd (dev).
+
+**Spec:** `docs/superpowers/specs/2026-09-03-server-cors-config-design.md`
+
+---
+
+## Background the engineer needs
+
+**What CORS is here.** The server has no authentication. CORS is enforced by
+browsers only: it decides which *web pages from other origins* may read
+responses from this server. `curl`, the server's own web UI, and every
+non-browser client ignore it entirely. So tightening it cannot break the UI or
+scripts — only cross-origin browser JavaScript.
+
+**Preflight.** Before a "non-simple" cross-origin request (anything that isn't
+a plain `GET`/`POST` with a safelisted content type), the browser sends
+`OPTIONS` with `Origin` and `Access-Control-Request-Method` headers. The server
+answers with `Access-Control-Allow-Origin` / `-Methods` / `-Headers`. tower-http's
+`CorsLayer` handles this automatically — you never write an `OPTIONS` route.
+Tests below drive preflight by sending `OPTIONS` with those headers by hand.
+
+**Where things live.**
+- `src/server/mod.rs` — `ServerArgs` (clap), `run()`, `build_state()`, `AppState`.
+  The hardcoded `CorsLayer` is at lines 206-210.
+- `src/server/ui.rs:304` — the only read of `AppState.cors`, the CSRF check.
+- `src/web/api_docs.rs:56` — the CORS note shown at `/api-docs`.
+- `docs/api.md` — **generated** from `api_docs.rs`. Never hand-edit; regenerate
+  with `UPDATE_API_DOCS=1 cargo test --test api_docs_md_test`.
+- `docs/server.md` — hand-written `cook server` reference.
+
+**Everything under `src/server/` is behind `#[cfg(feature = "server")]`** (see
+`src/lib.rs:20`). The `server` feature is on by default, so plain `cargo test`
+covers it.
+
+## File Structure
+
+- **Create** `src/server/cors.rs` — `CorsOrigins`, `CorsConfig`, validation,
+  layer construction, and the unit tests for validation. One responsibility:
+  turn flags into a CORS policy. Nothing else in the codebase needs to know how
+  tower-http is configured.
+- **Create** `tests/cors_test.rs` — end-to-end header assertions against a real
+  booted server, mirroring `tests/menu_api_test.rs`.
+- **Modify** `src/server/mod.rs` — declare the module, add the two flags, rename
+  `cors` → `csrf_check` on `ServerArgs` and `AppState`, call the validator in
+  `run()`, replace the hardcoded layer.
+- **Modify** `src/server/ui.rs` — one field rename at line 304.
+- **Modify** `src/web/api_docs.rs` — the CORS note text.
+- **Modify** `docs/server.md`, `docs/api.md` (regenerated).
+
+---
+
+### Task 1: `CorsConfig` validation
+
+**Files:**
+- Create: `src/server/cors.rs`
+- Modify: `src/server/mod.rs` (add `mod cors;`)
+- Test: `src/server/cors.rs` (inline `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Create the module file with types and a stub, plus the failing tests**
+
+Create `src/server/cors.rs` with exactly this content:
+
+```rust
+//! CORS policy for `cook server`, built from the `--cors-origin` and
+//! `--cors-allow-credentials` flags.
+//!
+//! CORS is enforced by browsers only, so this governs what cross-origin web
+//! pages may do with the API. The web UI itself, `curl`, and every non-browser
+//! client are unaffected by anything here.
+
+use anyhow::{bail, Result};
+use axum::http::{header, HeaderValue, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+/// Which origins may make cross-origin requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorsOrigins {
+    /// `--cors-origin '*'`, or no `--cors-origin` at all. Read-only: see
+    /// [`CorsConfig::methods`].
+    Any,
+    /// One or more explicit origins, in the order given on the command line.
+    List(Vec<HeaderValue>),
+}
+
+/// A validated CORS policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorsConfig {
+    origins: CorsOrigins,
+    allow_credentials: bool,
+}
+
+impl CorsConfig {
+    /// Validates a `--cors-origin` / `--cors-allow-credentials` combination.
+    ///
+    /// `origins` is the raw repeated flag; empty means the flag was not given.
+    pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self> {
+        todo!("Task 1 Step 3")
+    }
+
+    /// The methods this policy allows cross-origin.
+    ///
+    /// A wildcard origin means *any* page in the user's browser can reach the
+    /// server, so it gets read-only access. Naming an origin is an explicit
+    /// statement of trust, and unlocks the mutating routes.
+    pub fn methods(&self) -> Vec<Method> {
+        match &self.origins {
+            CorsOrigins::Any => vec![Method::GET],
+            CorsOrigins::List(_) => {
+                vec![Method::GET, Method::POST, Method::PUT, Method::DELETE]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origins(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_flag_defaults_to_any() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert_eq!(config.origins, CorsOrigins::Any);
+        assert!(!config.allow_credentials);
+    }
+
+    #[test]
+    fn explicit_wildcard_is_any() {
+        let config = CorsConfig::from_args(&origins(&["*"]), false).expect("valid");
+        assert_eq!(config.origins, CorsOrigins::Any);
+    }
+
+    #[test]
+    fn any_allows_only_get() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert_eq!(config.methods(), vec![Method::GET]);
+    }
+
+    #[test]
+    fn explicit_origins_keep_order_and_allow_mutation() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://a.test", "https://b.test:8443"]), false)
+                .expect("valid");
+        assert_eq!(
+            config.origins,
+            CorsOrigins::List(vec![
+                HeaderValue::from_static("http://a.test"),
+                HeaderValue::from_static("https://b.test:8443"),
+            ])
+        );
+        assert_eq!(
+            config.methods(),
+            vec![Method::GET, Method::POST, Method::PUT, Method::DELETE]
+        );
+    }
+
+    #[test]
+    fn wildcard_mixed_with_explicit_origin_is_rejected() {
+        let err = CorsConfig::from_args(&origins(&["*", "http://a.test"]), false)
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("cannot be combined"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    #[test]
+    fn credentials_with_wildcard_is_rejected() {
+        let err = CorsConfig::from_args(&[], true).expect_err("must reject");
+        assert!(
+            err.to_string().contains("--cors-origin"),
+            "error must point at the fix: {err}"
+        );
+    }
+
+    #[test]
+    fn credentials_with_explicit_origins_is_allowed() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
+        assert!(config.allow_credentials);
+    }
+
+    #[test]
+    fn origin_with_trailing_slash_is_rejected() {
+        let err =
+            CorsConfig::from_args(&origins(&["http://a.test/"]), false).expect_err("must reject");
+        assert!(
+            err.to_string().contains("http://a.test/"),
+            "error must name the bad origin: {err}"
+        );
+    }
+
+    #[test]
+    fn origin_without_scheme_is_rejected() {
+        CorsConfig::from_args(&origins(&["a.test"]), false).expect_err("must reject");
+    }
+
+    #[test]
+    fn empty_origin_is_rejected() {
+        CorsConfig::from_args(&origins(&[""]), false).expect_err("must reject");
+    }
+}
+```
+
+Then add the module declaration in `src/server/mod.rs`. The existing block at
+lines 49-53 reads:
+
+```rust
+mod fs_atomic;
+mod handlers;
+mod lsp_bridge;
+mod shopping_list_watcher;
+mod ui;
+```
+
+Change it to (alphabetical, matching the existing order):
+
+```rust
+mod cors;
+mod fs_atomic;
+mod handlers;
+mod lsp_bridge;
+mod shopping_list_watcher;
+mod ui;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib server::cors`
+
+Expected: the tests compile and every one of them fails, panicking at the
+`todo!("Task 1 Step 3")` with `not yet implemented`.
+
+Unused-import warnings for `bail`, `header`, `AllowOrigin` and `CorsLayer` are
+expected at this point — Step 3 uses `bail` and Task 2 uses the other three.
+Leave them; do not add an `allow(unused_imports)`.
+
+- [ ] **Step 3: Implement `from_args`**
+
+Replace the `todo!("Task 1 Step 3")` body with:
+
+```rust
+    pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self> {
+        let wildcard = origins.iter().any(|o| o == "*");
+        if wildcard && origins.len() > 1 {
+            bail!(
+                "--cors-origin '*' cannot be combined with explicit origins; \
+                 pass either '*' or a list of origins, not both"
+            );
+        }
+
+        let origins = if origins.is_empty() || wildcard {
+            CorsOrigins::Any
+        } else {
+            let parsed = origins
+                .iter()
+                .map(|origin| parse_origin(origin))
+                .collect::<Result<Vec<_>>>()?;
+            CorsOrigins::List(parsed)
+        };
+
+        if allow_credentials && origins == CorsOrigins::Any {
+            bail!(
+                "--cors-allow-credentials requires explicit --cors-origin values; \
+                 browsers reject credentialed requests against a wildcard origin"
+            );
+        }
+
+        Ok(Self {
+            origins,
+            allow_credentials,
+        })
+    }
+```
+
+And add this free function to the module, after the `impl CorsConfig` block:
+
+```rust
+/// Parses one `--cors-origin` value.
+///
+/// A browser sends a bare origin — scheme, host, optional port — in the
+/// `Origin` header. Anything richer (a path, a trailing slash) would compare
+/// unequal and silently never match, so it is rejected up front instead.
+fn parse_origin(origin: &str) -> Result<HeaderValue> {
+    let Some((scheme, rest)) = origin.split_once("://") else {
+        bail!("invalid --cors-origin {origin:?}: expected a scheme, e.g. http://localhost:3000");
+    };
+    if scheme.is_empty() || rest.is_empty() {
+        bail!("invalid --cors-origin {origin:?}: expected scheme://host[:port]");
+    }
+    if rest.contains('/') {
+        bail!(
+            "invalid --cors-origin {origin:?}: an origin has no path or trailing slash, \
+             e.g. http://localhost:3000"
+        );
+    }
+    HeaderValue::from_str(origin)
+        .map_err(|e| anyhow::anyhow!("invalid --cors-origin {origin:?}: {e}"))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib server::cors`
+
+Expected: `test result: ok. 10 passed`. Warnings about unused `header`,
+`AllowOrigin`, `CorsLayer` imports are expected and go away in Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/cors.rs src/server/mod.rs
+git commit -m "feat(server): validate CORS origin and credential flags
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+---
+
+### Task 2: Build the `CorsLayer`
+
+**Files:**
+- Modify: `src/server/cors.rs`
+- Test: `src/server/cors.rs` (inline tests)
+
+There is no way to inspect a built `CorsLayer` from a unit test — tower-http
+exposes no getters. The behaviour is covered end-to-end in Task 5. This task
+only adds the constructor and a smoke test that it does not panic (tower-http
+*does* panic on some invalid combinations, e.g. `AllowOrigin::list` containing
+a wildcard, so a construction test has real value).
+
+- [ ] **Step 1: Write the failing test**
+
+Add these two tests inside the existing `mod tests` block in
+`src/server/cors.rs`:
+
+```rust
+    #[test]
+    fn layer_builds_for_wildcard() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        let _layer = config.layer();
+    }
+
+    #[test]
+    fn layer_builds_for_explicit_origins_with_credentials() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
+        let _layer = config.layer();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib server::cors`
+
+Expected: compile error, `no method named 'layer' found for struct 'CorsConfig'`.
+
+- [ ] **Step 3: Implement `layer`**
+
+Add this method to the `impl CorsConfig` block in `src/server/cors.rs`, after
+`methods`:
+
+```rust
+    /// Builds the tower-http layer for this policy.
+    ///
+    /// `content-type` is always allowed: without it a cross-origin JSON `POST`
+    /// fails preflight no matter what the origin setting is, so there is
+    /// nothing here worth making configurable. The CORS-safelisted request
+    /// headers (`Accept`, `Accept-Language`, `Content-Language`) need no entry
+    /// — browsers permit them regardless.
+    pub fn layer(&self) -> CorsLayer {
+        let allow_origin = match &self.origins {
+            CorsOrigins::Any => AllowOrigin::any(),
+            CorsOrigins::List(list) => AllowOrigin::list(list.iter().cloned()),
+        };
+
+        CorsLayer::new()
+            .allow_origin(allow_origin)
+            .allow_methods(self.methods())
+            .allow_headers([header::CONTENT_TYPE])
+            .allow_credentials(self.allow_credentials)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --lib server::cors`
+
+Expected: `test result: ok. 12 passed`, with no unused-import warnings left.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/cors.rs
+git commit -m "feat(server): build the CORS layer from the validated config
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+---
+
+### Task 3: Wire the flags into `cook server`
+
+**Files:**
+- Modify: `src/server/mod.rs`
+
+No test in this task — it is pure wiring, and Task 5 tests the result through
+the real binary. Verification here is `cargo build` plus `--help` output.
+
+- [ ] **Step 1: Add the two flags to `ServerArgs`**
+
+In `src/server/mod.rs`, the `ServerArgs` struct currently ends with the `cors`
+field (lines 99-104):
+
+```rust
+    /// Enable cors verification
+    ///
+    /// When enabled, the POST /new path require a seemless
+    /// Origin and Host header.
+    #[arg(long = "no-cors", action = clap::ArgAction::SetFalse)]
+    cors: bool,
+```
+
+Leave that field alone for now (Task 4 renames it) and insert the two new
+fields **immediately before** it:
+
+```rust
+    /// Origin allowed to make cross-origin browser requests (repeatable)
+    ///
+    /// Pass once per origin, e.g. --cors-origin http://localhost:3000. Use "*"
+    /// for any origin, which is the default. A wildcard origin allows GET
+    /// only; naming explicit origins also allows POST, PUT and DELETE.
+    /// "*" cannot be combined with explicit origins.
+    #[arg(long = "cors-origin", value_name = "ORIGIN")]
+    cors_origin: Vec<String>,
+
+    /// Allow cross-origin requests to carry cookies and credentials
+    ///
+    /// Requires at least one explicit --cors-origin; browsers reject
+    /// credentialed requests against a wildcard origin.
+    #[arg(long = "cors-allow-credentials", default_value_t = false)]
+    cors_allow_credentials: bool,
+```
+
+- [ ] **Step 2: Validate the flags early in `run()`**
+
+In `run()`, the function currently opens with:
+
+```rust
+    let addr = match args.host {
+        Some(Some(addr)) => addr,
+        Some(None) => "::".parse()?,
+        None => [127, 0, 0, 1].into(),
+    };
+    let addr = SocketAddr::from((addr, args.port));
+    let open = args.open;
+
+    let state = build_state(ctx, args)?;
+```
+
+Insert the CORS validation **before** `let state = build_state(...)`, so a bad
+flag combination fails before anything is printed or bound:
+
+```rust
+    let addr = match args.host {
+        Some(Some(addr)) => addr,
+        Some(None) => "::".parse()?,
+        None => [127, 0, 0, 1].into(),
+    };
+    let addr = SocketAddr::from((addr, args.port));
+    let open = args.open;
+
+    // Validate before binding or printing anything, so a bad flag combination
+    // fails immediately rather than after the "Listening on ..." banner.
+    let cors = cors::CorsConfig::from_args(&args.cors_origin, args.cors_allow_credentials)?;
+
+    let state = build_state(ctx, args)?;
+```
+
+- [ ] **Step 3: Replace the hardcoded layer**
+
+Still in `run()`, this block (lines 206-210 before your edits):
+
+```rust
+        .layer(
+            CorsLayer::new()
+                .allow_origin("*".parse::<HeaderValue>().unwrap())
+                .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]),
+        );
+```
+
+becomes:
+
+```rust
+        .layer(cors.layer());
+```
+
+- [ ] **Step 4: Drop the now-unused imports**
+
+Line 46 currently reads:
+
+```rust
+use tower_http::{cors::CorsLayer, services::ServeDir};
+```
+
+Change it to:
+
+```rust
+use tower_http::services::ServeDir;
+```
+
+Line 37 currently reads:
+
+```rust
+    http::{header, HeaderValue, Method, Response, StatusCode},
+```
+
+`HeaderValue` and `Method` were only used by the block you just deleted;
+`header`, `Response` and `StatusCode` are still used by `serve_static` at
+`src/server/mod.rs:500-516`. So change it to:
+
+```rust
+    http::{header, Response, StatusCode},
+```
+
+- [ ] **Step 5: Build and check the help text**
+
+Run: `cargo build`
+Expected: compiles with no warnings.
+
+Run: `cargo run -- server --help`
+Expected: the output lists `--cors-origin <ORIGIN>` and
+`--cors-allow-credentials`.
+
+Run: `cargo run -- server --cors-allow-credentials`
+Expected: exits non-zero, prints
+`Error: --cors-allow-credentials requires explicit --cors-origin values; browsers reject credentialed requests against a wildcard origin`,
+and does **not** print "Listening on".
+
+Run: `cargo run -- server --cors-origin '*' --cors-origin http://a.test`
+Expected: exits non-zero with the "cannot be combined with explicit origins"
+message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/mod.rs
+git commit -m "feat(server): add --cors-origin and --cors-allow-credentials
+
+The default is now a wildcard origin restricted to GET. Naming explicit
+origins unlocks POST/PUT/DELETE, and content-type is always allowed so
+cross-origin JSON requests can pass preflight.
+
+Closes #465
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+---
+
+### Task 4: Rename `--no-cors` to `--no-csrf-check`
+
+**Files:**
+- Modify: `src/server/mod.rs`
+- Modify: `src/server/ui.rs:304`
+
+This flag never touched the CORS layer. It disables a same-origin check on the
+HTML form `POST /new`, which is CSRF protection. Standing next to
+`--cors-origin`, the old name is actively misleading. `alias` (not
+`visible_alias`) keeps the old spelling working without showing it in `--help`.
+
+- [ ] **Step 1: Rename the `ServerArgs` field**
+
+In `src/server/mod.rs`, replace:
+
+```rust
+    /// Enable cors verification
+    ///
+    /// When enabled, the POST /new path require a seemless
+    /// Origin and Host header.
+    #[arg(long = "no-cors", action = clap::ArgAction::SetFalse)]
+    cors: bool,
+```
+
+with:
+
+```rust
+    /// Disable the same-origin (CSRF) check on the new-recipe form
+    ///
+    /// By default, POST /new is rejected unless the request's Origin or
+    /// Referer matches the Host it was sent to. This has nothing to do with
+    /// the --cors-* flags, which govern the API's cross-origin policy. The
+    /// former spelling --no-cors still works.
+    #[arg(long = "no-csrf-check", alias = "no-cors", action = clap::ArgAction::SetFalse)]
+    csrf_check: bool,
+```
+
+- [ ] **Step 2: Rename the `AppState` field and its initialiser**
+
+In the `AppState` struct definition, replace:
+
+```rust
+    pub cors: bool,
+```
+
+with:
+
+```rust
+    /// When true, `POST /new` requires a same-origin `Origin`/`Referer`.
+    /// Cleared by `--no-csrf-check`. Unrelated to the CORS layer.
+    pub csrf_check: bool,
+```
+
+In `build_state`, in the `Ok(Arc::new(AppState { .. }))` literal, replace:
+
+```rust
+        cors: args.cors,
+```
+
+with:
+
+```rust
+        csrf_check: args.csrf_check,
+```
+
+- [ ] **Step 3: Update the single read site**
+
+In `src/server/ui.rs`, line 304 reads:
+
+```rust
+    if state.cors && !validate_same_origin(&headers, &host) {
+```
+
+Change it to:
+
+```rust
+    if state.csrf_check && !validate_same_origin(&headers, &host) {
+```
+
+- [ ] **Step 4: Verify no other references remain**
+
+Run: `grep -rn "state.cors\|args.cors\b\|\"no-cors\"" src/`
+Expected: only the `alias = "no-cors"` line in `src/server/mod.rs`.
+
+Run: `cargo build`
+Expected: compiles with no warnings.
+
+Run: `cargo run -- server --no-cors --help`
+Expected: prints the help text (the alias is accepted, not an unknown-argument
+error). The `--no-cors` spelling itself does not appear in the options list.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/mod.rs src/server/ui.rs
+git commit -m "refactor(server): rename --no-cors to --no-csrf-check
+
+The flag gates the same-origin check on POST /new, not the CORS layer.
+--no-cors is kept as a hidden alias so existing invocations keep working.
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+---
+
+### Task 5: End-to-end CORS header tests
+
+**Files:**
+- Create: `tests/cors_test.rs`
+
+This mirrors `tests/menu_api_test.rs`: boot the real `cook` binary on an
+ephemeral port against a temp recipe directory, then assert response headers.
+`assert_cmd::cargo::cargo_bin("cook")` resolves the just-built binary, so
+`cargo test` builds it for you.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/cors_test.rs`:
+
+```rust
+//! End-to-end checks on the CORS headers `cook server` returns, for each
+//! `--cors-origin` / `--cors-allow-credentials` combination.
+//!
+//! `CorsConfig` is unit-tested in `src/server/cors.rs`, but nothing there can
+//! observe what tower-http actually puts on the wire. These tests drive real
+//! preflight requests against a booted server to close that gap.
+
+#![cfg(feature = "server")]
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// Kills the spawned server when the test ends, pass or panic.
+struct ServerGuard {
+    child: Child,
+    port: u16,
+    #[allow(dead_code)]
+    dir: TempDir,
+}
+
+impl ServerGuard {
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, path)
+    }
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+fn write_fixture(dir: &TempDir) {
+    std::fs::write(
+        dir.path().join("Toast.cook"),
+        "---\ntitle: Toast\n---\n\nToast the @bread{2%slice}.\n",
+    )
+    .expect("write fixture");
+}
+
+/// `free_port` only reserves a port long enough to learn its number, so with
+/// several tests booting servers at once another one can claim it first. The
+/// server exits 1 on a bound port, so retry with a fresh one.
+async fn start_server(cors_args: &[&str]) -> ServerGuard {
+    for _ in 0..5 {
+        if let Some(server) = try_start_server(cors_args).await {
+            return server;
+        }
+    }
+    panic!("could not start cook server on a free port after 5 attempts");
+}
+
+async fn try_start_server(cors_args: &[&str]) -> Option<ServerGuard> {
+    let dir = TempDir::new().expect("temp dir");
+    write_fixture(&dir);
+
+    let port = free_port();
+    let child = Command::new(assert_cmd::cargo::cargo_bin("cook"))
+        .arg("server")
+        .arg(dir.path())
+        .arg("--port")
+        .arg(port.to_string())
+        .args(cors_args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cook server");
+
+    let mut guard = ServerGuard { child, port, dir };
+
+    let client = reqwest::Client::new();
+    let url = guard.url("/api/recipes");
+    for _ in 0..200 {
+        if guard.child.try_wait().expect("poll server").is_some() {
+            // Port was taken between reserving and binding it.
+            return None;
+        }
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                return Some(guard);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("cook server on port {port} never became ready");
+}
+
+/// Sends a CORS preflight and returns the response headers as
+/// `(name, value)` pairs, lowercased names.
+async fn preflight(server: &ServerGuard, origin: &str, method: &str) -> Vec<(String, String)> {
+    let resp = reqwest::Client::new()
+        .request(reqwest::Method::OPTIONS, server.url("/api/recipes"))
+        .header("Origin", origin)
+        .header("Access-Control-Request-Method", method)
+        .header("Access-Control-Request-Headers", "content-type")
+        .send()
+        .await
+        .expect("send preflight");
+
+    resp.headers()
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_lowercase(),
+                v.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
+}
+
+fn header<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(k, _)| k == name)
+        .map(|(_, v)| v.as_str())
+}
+
+#[tokio::test]
+async fn default_policy_allows_get_from_any_origin() {
+    let server = start_server(&[]).await;
+    let headers = preflight(&server, "http://evil.test", "GET").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin"),
+        Some("*"),
+        "the default policy must stay open for reads"
+    );
+    assert!(
+        header(&headers, "access-control-allow-methods")
+            .expect("allow-methods")
+            .to_uppercase()
+            .contains("GET"),
+        "GET must be allowed: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn default_policy_refuses_cross_origin_post() {
+    let server = start_server(&[]).await;
+    let headers = preflight(&server, "http://evil.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin"),
+        None,
+        "a wildcard origin must not unlock mutating methods: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_origin_allows_post_and_content_type() {
+    let server = start_server(&["--cors-origin", "http://app.test"]).await;
+    let headers = preflight(&server, "http://app.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin"),
+        Some("http://app.test")
+    );
+    assert!(
+        header(&headers, "access-control-allow-methods")
+            .expect("allow-methods")
+            .to_uppercase()
+            .contains("POST"),
+        "POST must be allowed for an explicit origin: {headers:?}"
+    );
+    assert!(
+        header(&headers, "access-control-allow-headers")
+            .expect("allow-headers")
+            .to_lowercase()
+            .contains("content-type"),
+        "content-type must always be allowed, or JSON POSTs fail preflight: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_origin_refuses_other_origins() {
+    let server = start_server(&["--cors-origin", "http://app.test"]).await;
+    let headers = preflight(&server, "http://evil.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin"),
+        None,
+        "an unlisted origin must not be allowed: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn credentials_are_allowed_with_an_explicit_origin() {
+    let server = start_server(&[
+        "--cors-origin",
+        "http://app.test",
+        "--cors-allow-credentials",
+    ])
+    .await;
+    let headers = preflight(&server, "http://app.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-credentials"),
+        Some("true")
+    );
+}
+
+#[tokio::test]
+async fn credentials_without_an_origin_is_a_startup_error() {
+    let dir = TempDir::new().expect("temp dir");
+    write_fixture(&dir);
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin("cook"))
+        .arg("server")
+        .arg(dir.path())
+        .arg("--port")
+        .arg(free_port().to_string())
+        .arg("--cors-allow-credentials")
+        .output()
+        .expect("run cook server");
+
+    assert!(!output.status.success(), "must exit non-zero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--cors-origin"),
+        "the error must point at the fix, got: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Listening on"),
+        "must fail before binding, got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_mixed_with_explicit_origin_is_a_startup_error() {
+    let dir = TempDir::new().expect("temp dir");
+    write_fixture(&dir);
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin("cook"))
+        .arg("server")
+        .arg(dir.path())
+        .arg("--port")
+        .arg(free_port().to_string())
+        .arg("--cors-origin")
+        .arg("*")
+        .arg("--cors-origin")
+        .arg("http://app.test")
+        .output()
+        .expect("run cook server");
+
+    assert!(!output.status.success(), "must exit non-zero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be combined"),
+        "unhelpful error: {stderr}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test --test cors_test`
+
+Expected: `test result: ok. 7 passed`. Tasks 1-4 already implemented the
+behaviour, so these should pass on the first run — that is fine; the unit tests
+in Task 1 were the failing-first step for the logic, and this task's job is to
+prove the wire format.
+
+If `default_policy_refuses_cross_origin_post` or
+`explicit_origin_refuses_other_origins` fails because
+`access-control-allow-origin` is present, the layer is more permissive than
+intended — re-check `CorsConfig::methods` and `layer` from Tasks 1-2 before
+touching the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/cors_test.rs
+git commit -m "test(server): cover CORS headers end to end
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `src/web/api_docs.rs:53-57`
+- Modify: `docs/api.md` (generated — do not hand-edit)
+- Modify: `docs/server.md`
+
+- [ ] **Step 1: Update the API docs note**
+
+In `src/web/api_docs.rs`, replace:
+
+```rust
+            note(
+                "CORS",
+                "All origins are allowed, for the methods GET, POST, PUT and DELETE.",
+            ),
+```
+
+with:
+
+```rust
+            note(
+                "CORS",
+                "`GET` is allowed from any origin. Cross-origin `POST`, `PUT` and \
+                 `DELETE` require the server to be started with one or more \
+                 `--cors-origin <ORIGIN>` flags; `content-type` is always an allowed \
+                 request header.",
+            ),
+```
+
+- [ ] **Step 2: Confirm the docs test now fails**
+
+Run: `cargo test --test api_docs_md_test`
+
+Expected: FAIL with "docs/api.md is stale — it no longer matches
+src/web/api_docs.rs."
+
+- [ ] **Step 3: Regenerate `docs/api.md`**
+
+Run: `UPDATE_API_DOCS=1 cargo test --test api_docs_md_test`
+
+Expected: prints `regenerated .../docs/api.md` and passes.
+
+Run: `git diff docs/api.md`
+
+Expected: only the `- **CORS:**` bullet changed.
+
+- [ ] **Step 4: Verify it now passes without the env var**
+
+Run: `cargo test --test api_docs_md_test`
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 5: Update `docs/server.md`**
+
+The Options table currently reads:
+
+```markdown
+| Option | Description |
+|--------|-------------|
+| `--host [<ADDRESS>]` | Allow connections from external hosts (default: localhost only). Optionally bind to a specific address. |
+| `-p, --port <PORT>` | Port number (default: 9080) |
+| `--open` | Automatically open the web interface in your default browser |
+```
+
+Replace it with:
+
+```markdown
+| Option | Description |
+|--------|-------------|
+| `--host [<ADDRESS>]` | Allow connections from external hosts (default: localhost only). Optionally bind to a specific address. |
+| `-p, --port <PORT>` | Port number (default: 9080) |
+| `--open` | Automatically open the web interface in your default browser |
+| `--cors-origin <ORIGIN>` | Origin allowed to make cross-origin browser requests. Repeatable. `*` for any origin (default). |
+| `--cors-allow-credentials` | Allow cross-origin requests to carry cookies and credentials. Requires an explicit `--cors-origin`. |
+| `--no-csrf-check` | Disable the same-origin check on the new-recipe form (`POST /new`). |
+```
+
+In the Examples block, after the `cook server --host` example, append:
+
+```bash
+# Let a frontend at localhost:3000 use the full API, including writes
+cook server --cors-origin http://localhost:3000
+```
+
+In the Notes list, insert these two bullets directly after the
+`Use --host on trusted networks only` bullet:
+
+```markdown
+- Cross-origin browser requests default to `GET` from any origin. Naming origins with `--cors-origin` also permits `POST`, `PUT` and `DELETE` from them — so a page you have not listed cannot modify your recipes. CORS is enforced by browsers only; `curl` and other non-browser clients are unaffected either way. See [the API reference](api.md).
+- `--no-csrf-check` is unrelated to the `--cors-*` flags: it turns off the same-origin check on the web UI's new-recipe form. Its former spelling, `--no-cors`, still works.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/web/api_docs.rs docs/api.md docs/server.md
+git commit -m "docs: document the configurable server CORS flags
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+- [ ] **Step 7: Note the website follow-up**
+
+`docs/api.md` and `docs/server.md` are the source of truth; cooklang.org syncs
+from them one-directionally via its own `scripts/sync-cli-docs.sh`. Do **not**
+edit the website repo here. Mention in the PR description that the sync script
+should be re-run after merge.
+
+---
+
+### Task 7: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt`
+Then: `git diff --stat`
+Expected: either no changes, or formatting-only changes to the files you
+touched. If there are changes, commit them:
+
+```bash
+git add -A
+git commit -m "style: cargo fmt
+
+Claude-Session: https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh"
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings, no errors. Fix anything reported and commit the fix.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `cargo test`
+Expected: everything passes. Pay particular attention to `cors_test`,
+`api_docs_md_test`, and any snapshot test that captures `cook server --help`
+output — if a snapshot covers the help text, review the diff and accept it with
+`cargo insta accept` only after confirming the new flags are what changed.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+cargo run -- server ./seed --port 9099 &
+sleep 2
+# Default: GET allowed from anywhere
+curl -si -X OPTIONS http://127.0.0.1:9099/api/recipes \
+  -H 'Origin: http://evil.test' -H 'Access-Control-Request-Method: GET' \
+  | grep -i access-control
+# Default: POST not allowed
+curl -si -X OPTIONS http://127.0.0.1:9099/api/recipes \
+  -H 'Origin: http://evil.test' -H 'Access-Control-Request-Method: POST' \
+  | grep -i access-control
+kill %1
+```
+
+Expected: the first `curl` prints `access-control-allow-origin: *` and an
+allow-methods line containing `GET`; the second prints nothing.
+
+Then confirm the web UI still works normally:
+
+```bash
+cargo run -- server ./seed --port 9099 --open
+```
+
+Expected: recipes list, a recipe page, and the shopping list all work — CORS
+does not apply to same-origin requests, so nothing in the UI should change.
+Stop the server with Ctrl-C.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(server): make CORS configuration configurable" --body "$(cat <<'EOF'
+Closes #465.
+
+`cook server` applied one hardcoded CORS policy that was simultaneously too
+permissive (any page could reach the mutating routes of a `--host`-exposed
+server) and too restrictive (`allow_headers` was never set, so cross-origin
+JSON `POST` failed preflight regardless).
+
+- `--cors-origin <ORIGIN>` — repeatable; `*` for any origin, the default.
+- `--cors-allow-credentials` — requires explicit origins.
+- A wildcard origin now allows `GET` only. Naming explicit origins also allows
+  `POST`, `PUT` and `DELETE`.
+- `content-type` is always an allowed request header.
+- `--no-cors` is renamed `--no-csrf-check`, since it gates the same-origin
+  check on `POST /new` and never touched the CORS layer. The old spelling
+  still works as a hidden alias.
+
+**Behaviour change:** cross-origin `POST`/`PUT`/`DELETE` now requires
+`--cors-origin`. Same-origin traffic — the web UI, `curl`, every non-browser
+client — is unaffected, since CORS is browser-enforced only.
+
+Design: `docs/superpowers/specs/2026-09-03-server-cors-config-design.md`
+
+**Follow-up:** re-run cooklang.org's `scripts/sync-cli-docs.sh` after merge to
+pick up the `docs/api.md` and `docs/server.md` changes.
+
+https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-09-03-server-cors-config-design.md
+++ b/docs/superpowers/specs/2026-09-03-server-cors-config-design.md
@@ -38,7 +38,7 @@ actively misleading.
 
 ## Decisions
 
-### Default: wildcard origin, `GET` only
+### Default: wildcard origin, reads only
 
 Chosen over keeping `*` for all methods (preserves the security hole the issue
 opens with) and over dropping the CORS layer entirely by default (a hard break
@@ -48,10 +48,10 @@ This is the shape suggested in the issue's comment: keep `*` so read-only
 integrations keep working, but stop cross-origin mutation unless the operator
 opts in.
 
-**This is a behaviour change.** Cross-origin `POST`/`PUT`/`DELETE` stops
-working until the user passes `--cors-origin`. Same-origin traffic is
-unaffected — the web UI itself, `curl`, and every non-browser client never
-consult CORS, which is browser-enforced only.
+**This is a behaviour change.** Cross-origin `POST`/`PUT`/`DELETE` from a
+browser stops working until the user passes `--cors-origin`. Same-origin
+traffic is unaffected: the web UI's own `Origin` matches its `Host`, and
+`curl` and other non-browser clients send no `Origin` at all.
 
 ### Flags
 
@@ -59,14 +59,63 @@ consult CORS, which is browser-enforced only.
 |---|---|
 | `--cors-origin <ORIGIN>` | Repeatable. `*` selects the wildcard. Omitted → `*`. |
 | `--cors-allow-credentials` | Requires explicit origins; errors when origins are `*`. |
-| `--no-csrf-check` | Renamed from `--no-cors`, hidden clap alias keeps the old spelling working. Behaviour unchanged. |
+| `--no-csrf-check` | Renamed from `--no-cors`, hidden clap alias keeps the old spelling working. Now governs both the same-origin check on `POST /new` and the cross-origin write guard. |
 
 Resolved policy:
 
-| Origins | `allow_origin` | `allow_methods` | `allow_headers` | `allow_credentials` |
-|---|---|---|---|---|
-| `*` (default) | any | `GET` | `content-type` | never (rejected at parse) |
-| explicit list | that list | `GET, POST, PUT, DELETE` | `content-type` | opt-in |
+| Origins | `allow_origin` | `allow_methods` | `allow_headers` | `allow_credentials` | write guard |
+|---|---|---|---|---|---|
+| `*` (default) | any | `GET` | `content-type` | never (rejected at parse) | rejects non-`GET`/`HEAD` carrying a cross-origin `Origin` |
+| explicit list | that list | `GET, POST, PUT, DELETE` | `content-type` | opt-in | additionally allows the listed origins |
+
+### Correction: `allow_methods` cannot enforce read-only
+
+The first version of this design assumed `allow_methods([GET])` would stop
+cross-origin writes. It does not. Per the Fetch standard's CORS-preflight step,
+the `Access-Control-Allow-Methods` list is consulted **only when the request's
+method is not CORS-safelisted**, and `GET`, `HEAD` and `POST` are all
+safelisted. So the method list blocks `PUT` and `DELETE` but never `POST`.
+Verified in a real browser: with `allow_methods([GET])` and
+`allow_headers([content-type])`, a cross-origin page successfully wrote to
+`seed/config/pantry.conf` through `POST /api/pantry/add`.
+
+Worse, that combination is *more* permissive than the hardcoded layer it
+replaces. Today the only thing blocking a cross-origin JSON `POST` is that
+`allow_headers` is unset, so the preflight fails on `content-type`. Supplying
+`content-type` — which the issue rightly asks for, and which legitimate
+integrations need — removes that accidental protection.
+
+Relying on the accident is not an option either: it holds only because axum's
+`Json` extractor rejects the content types that would make a `POST` a simple,
+un-preflighted request. That is a property of the extractors, not a policy, and
+it would break silently the first time a route accepted form-encoded input.
+
+So the read-only guarantee is enforced **server-side**, by a small middleware,
+and the CORS headers are left to describe the policy rather than enforce it.
+
+### The cross-origin write guard
+
+A middleware, applied only to non-preflight requests (the CORS layer is
+outermost, so it answers `OPTIONS` preflights before this runs):
+
+1. `GET`, `HEAD` and `OPTIONS` pass.
+2. A request with no `Origin` header passes. `curl`, scripts and every
+   non-browser client send none, and the API has no authentication — blocking
+   them would break every existing integration to no benefit, since a client
+   that sets no `Origin` is not a browser acting on some user's behalf.
+3. An `Origin` matching the request's `Host` passes. Browsers send `Origin` on
+   same-origin `POST`s too, so the web UI's own writes land here.
+4. An `Origin` in the explicit `--cors-origin` list passes.
+5. Anything else gets `403` with the API's standard `{"error": ...}` body.
+
+Rule 4 is what gives reverse-proxy deployments a clean path: when the proxy
+forwards a `Host` that does not match the browser's `Origin`, naming the public
+origin with `--cors-origin` restores writes without disabling anything.
+
+`--no-csrf-check` skips the guard entirely, alongside the same-origin check it
+already governs on `POST /new`. That makes the flag's name accurate — it is now
+the single switch for same-origin enforcement — and leaves an escape hatch for
+deployments where neither rule 3 nor rule 4 fits.
 
 **Methods are derived from origins, not their own flag.** A wildcard origin is
 exactly the case where mutation should be unreachable; naming an origin is
@@ -109,8 +158,27 @@ impl CorsConfig {
     /// Validates the flag combination.
     pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self>;
     pub fn layer(&self) -> CorsLayer;
+    /// True when a request carrying this `Origin` may use a mutating method.
+    pub fn allows_write_from(&self, origin: &str, host: &str) -> bool;
 }
+
+/// Rules 1-5 of the write guard, as axum middleware.
+pub async fn write_guard(
+    State(config): State<Arc<CorsConfig>>,
+    request: Request,
+    next: Next,
+) -> Response;
+
+/// Shared by the guard and `ui::validate_same_origin`.
+pub(super) fn origin_matches_host(origin: &str, host: &str) -> bool;
 ```
+
+The module owns one question — who may do what cross-origin — so both the
+headers that describe the policy and the guard that enforces it live here.
+`origin_matches_host` replaces the origin/host comparison duplicated inside
+`ui::validate_same_origin`; that function keeps its own "no `Origin` and no
+`Referer` → reject" rule, which is right for an HTML form and wrong for the
+API, where a missing `Origin` means a non-browser client.
 
 `from_args` rules:
 
@@ -133,15 +201,19 @@ impl CorsConfig {
 `run()` calls `CorsConfig::from_args(..)?` **before** `build_state` and before
 binding the socket, so a bad combination fails immediately rather than after
 the "Listening on…" banner. The hardcoded block at `src/server/mod.rs:206-210`
-becomes `.layer(cors.layer())`.
+becomes `.layer(cors.layer())`. The guard is added as
+`axum::middleware::from_fn_with_state(Arc::new(cors), cors::write_guard)`,
+inside the CORS layer, and only when `csrf_check` is set — when it is not, the
+layer is simply never added.
 
 ### The rename
 
-Three sites: the `ServerArgs` field (`cors: bool` → `csrf_check: bool`, with
+Four sites now: the `ServerArgs` field (`cors: bool` → `csrf_check: bool`, with
 `#[arg(long = "no-csrf-check", alias = "no-cors", action = SetFalse)]`),
-`AppState.cors` → `AppState.csrf_check`, and its single read at
-`src/server/ui.rs:304`. `alias` rather than `visible_alias`, so the old
-spelling keeps working without cluttering `--help`.
+`AppState.cors` → `AppState.csrf_check`, its read at `src/server/ui.rs:304`,
+and the new decision in `run()` about whether to add the guard. `alias` rather
+than `visible_alias`, so the old spelling keeps working without cluttering
+`--help`.
 
 ## Testing
 
@@ -153,16 +225,31 @@ Unit tests in `src/server/cors.rs` covering `from_args`:
 - credentials + wildcard → error
 - credentials + explicit origins → ok
 - `http://app.test/` → error
+- origins that could never match a browser's `Origin` (wrong case, whitespace,
+  path, query, fragment, userinfo, bad port) → error
+- bracketed IPv6 and non-`http` schemes (`chrome-extension://…`) → accepted
+
+Unit tests for `allows_write_from` and `origin_matches_host`: same-origin with
+and without a port, a listed origin, an unlisted origin, and a host that
+differs only by port.
 
 Integration tests in `tests/cors_test.rs`, following the server-booting pattern
 of `tests/menu_api_test.rs` (ephemeral port, `ServerGuard`, `reqwest`):
 
 - Default policy: preflight with `Access-Control-Request-Method: GET` →
-  `access-control-allow-origin: *`; the same preflight with `POST` → not
-  allowed.
+  `access-control-allow-origin: *`; the same preflight with `PUT` →
+  `access-control-allow-methods: GET`, so the browser blocks it.
+- **Default policy, real cross-origin `POST`** → `403`. This is the test that
+  matters: a preflight assertion cannot show it, because `AllowOrigin::any()`
+  always answers `*` and `POST` is CORS-safelisted.
+- Default policy, same-origin `POST` (`Origin` equal to the server's own
+  authority) → not `403`. Proves the web UI still works.
+- Default policy, `POST` with no `Origin` header → not `403`. Proves `curl` and
+  existing scripts still work.
 - `--cors-origin http://app.test`: `POST` preflight from `http://app.test` →
-  allowed, `access-control-allow-headers: content-type`; from
-  `http://evil.test` → not allowed.
+  allowed, `access-control-allow-headers: content-type`; a real `POST` from
+  `http://app.test` → not `403`; from `http://evil.test` → `403`.
+- `--no-csrf-check`: cross-origin `POST` from `http://evil.test` → not `403`.
 - `--cors-origin http://app.test --cors-allow-credentials` →
   `access-control-allow-credentials: true`.
 - `--cors-allow-credentials` alone → non-zero exit, message names the conflict.
@@ -173,7 +260,8 @@ of `tests/menu_api_test.rs` (ephemeral port, `ServerGuard`, `reqwest`):
   Notes bullet stating the default. `--no-csrf-check` gets documented for the
   first time.
 - `src/web/api_docs.rs:56`: the CORS note is rewritten to describe the
-  `GET`-by-default policy and point at `--cors-origin`.
+  reads-by-default policy, the `403` on a cross-origin write, and
+  `--cors-origin`.
 - `docs/api.md` is **generated** from that file and guarded by
   `tests/api_docs_md_test.rs`. Regenerate with
   `UPDATE_API_DOCS=1 cargo test --test api_docs_md_test`; never hand-edit it.

--- a/docs/superpowers/specs/2026-09-03-server-cors-config-design.md
+++ b/docs/superpowers/specs/2026-09-03-server-cors-config-design.md
@@ -1,0 +1,181 @@
+# `cook server`: configurable CORS
+
+**Date:** 2026-09-03
+**Status:** Approved, ready for planning
+**Issue:** [#465](https://github.com/cooklang/cookcli/issues/465) — "server: make CORS configuration configurable"
+
+## Problem
+
+`cook server` applies one hardcoded CORS policy (`src/server/mod.rs:206-210`):
+
+```rust
+CorsLayer::new()
+    .allow_origin("*".parse::<HeaderValue>().unwrap())
+    .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]);
+```
+
+It is wrong in both directions at once.
+
+**Too permissive.** Any page open in the user's browser can call the API of a
+running server, including the mutating `POST`/`PUT`/`DELETE` routes — shopping
+list, recipe editing, pantry. That matters more since `--host` started exposing
+the server on the LAN. There is no way to lock it down.
+
+**Too restrictive where it counts.** `allow_headers` is never set, so
+tower-http defaults to allowing none. A cross-origin `POST` carrying
+`Content-Type: application/json` fails preflight, so the wide-open method list
+buys legitimate integrations nothing. `allow_credentials` cannot be used at
+all, because it is invalid alongside a wildcard origin. Anyone building a
+custom frontend has to patch the binary.
+
+### The `--no-cors` name is already taken
+
+`ServerArgs` has a `--no-cors` flag today. It does not touch `CorsLayer`. It
+disables a same-origin CSRF check on the HTML form `POST /new`
+(`src/server/ui.rs:304`, reading `AppState.cors`). It is undocumented in
+`docs/server.md`. Adding `--cors-origin` beside it would make the collision
+actively misleading.
+
+## Decisions
+
+### Default: wildcard origin, `GET` only
+
+Chosen over keeping `*` for all methods (preserves the security hole the issue
+opens with) and over dropping the CORS layer entirely by default (a hard break
+for custom frontends, with a browser error that gives no hint about the flag).
+
+This is the shape suggested in the issue's comment: keep `*` so read-only
+integrations keep working, but stop cross-origin mutation unless the operator
+opts in.
+
+**This is a behaviour change.** Cross-origin `POST`/`PUT`/`DELETE` stops
+working until the user passes `--cors-origin`. Same-origin traffic is
+unaffected — the web UI itself, `curl`, and every non-browser client never
+consult CORS, which is browser-enforced only.
+
+### Flags
+
+| Flag | Behaviour |
+|---|---|
+| `--cors-origin <ORIGIN>` | Repeatable. `*` selects the wildcard. Omitted → `*`. |
+| `--cors-allow-credentials` | Requires explicit origins; errors when origins are `*`. |
+| `--no-csrf-check` | Renamed from `--no-cors`, hidden clap alias keeps the old spelling working. Behaviour unchanged. |
+
+Resolved policy:
+
+| Origins | `allow_origin` | `allow_methods` | `allow_headers` | `allow_credentials` |
+|---|---|---|---|---|
+| `*` (default) | any | `GET` | `content-type` | never (rejected at parse) |
+| explicit list | that list | `GET, POST, PUT, DELETE` | `content-type` | opt-in |
+
+**Methods are derived from origins, not their own flag.** A wildcard origin is
+exactly the case where mutation should be unreachable; naming an origin is
+exactly the statement "I trust this app". A `--cors-allow-method` flag would
+let a user reconstruct today's insecure default by accident and adds a knob to
+document and test that nobody needs.
+
+**`content-type` is allowed unconditionally**, so no `--cors-allow-header`
+flag. Without it, cross-origin JSON `POST` fails preflight whatever the origin
+setting is — there is no configuration here worth exposing. The three
+CORS-safelisted request headers (`Accept`, `Accept-Language`,
+`Content-Language`) are permitted by the browser regardless and need no entry.
+
+### No config file
+
+The issue asks whether this should be expressible in a config file. No. The
+comment's point was that CORS settings should be set the same way as `--host`
+and `--port`, and those are flags only. A config file is a separate, broader
+change to the whole server surface.
+
+## Design
+
+### `src/server/cors.rs` (new)
+
+The policy becomes a validated value rather than an inline builder chain, so
+the rules are unit-testable without booting a server:
+
+```rust
+pub enum CorsOrigins {
+    Any,
+    List(Vec<HeaderValue>),
+}
+
+pub struct CorsConfig {
+    origins: CorsOrigins,
+    allow_credentials: bool,
+}
+
+impl CorsConfig {
+    /// Validates the flag combination.
+    pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self>;
+    pub fn layer(&self) -> CorsLayer;
+}
+```
+
+`from_args` rules:
+
+- Empty `origins` → `CorsOrigins::Any`.
+- An entry of `*` must be the only entry. Mixed with an explicit origin →
+  error naming the conflict.
+- Each explicit origin must parse as a `HeaderValue` and be a bare origin —
+  scheme, host, optional port; no path, no trailing slash. `http://app.test/`
+  is an error, because a browser sends `Origin: http://app.test` and a trailing
+  slash would silently never match.
+- `allow_credentials` with `CorsOrigins::Any` → error telling the user to name
+  explicit origins.
+
+`layer()` maps the value onto tower-http: `AllowOrigin::any()` or
+`AllowOrigin::list(..)`, the method list from the table above,
+`[header::CONTENT_TYPE]`, and `allow_credentials` when set.
+
+### `src/server/mod.rs`
+
+`run()` calls `CorsConfig::from_args(..)?` **before** `build_state` and before
+binding the socket, so a bad combination fails immediately rather than after
+the "Listening on…" banner. The hardcoded block at `src/server/mod.rs:206-210`
+becomes `.layer(cors.layer())`.
+
+### The rename
+
+Three sites: the `ServerArgs` field (`cors: bool` → `csrf_check: bool`, with
+`#[arg(long = "no-csrf-check", alias = "no-cors", action = SetFalse)]`),
+`AppState.cors` → `AppState.csrf_check`, and its single read at
+`src/server/ui.rs:304`. `alias` rather than `visible_alias`, so the old
+spelling keeps working without cluttering `--help`.
+
+## Testing
+
+Unit tests in `src/server/cors.rs` covering `from_args`:
+
+- no origins → `Any`
+- explicit list → `List` in order
+- `*` mixed with an explicit origin → error
+- credentials + wildcard → error
+- credentials + explicit origins → ok
+- `http://app.test/` → error
+
+Integration tests in `tests/cors_test.rs`, following the server-booting pattern
+of `tests/menu_api_test.rs` (ephemeral port, `ServerGuard`, `reqwest`):
+
+- Default policy: preflight with `Access-Control-Request-Method: GET` →
+  `access-control-allow-origin: *`; the same preflight with `POST` → not
+  allowed.
+- `--cors-origin http://app.test`: `POST` preflight from `http://app.test` →
+  allowed, `access-control-allow-headers: content-type`; from
+  `http://evil.test` → not allowed.
+- `--cors-origin http://app.test --cors-allow-credentials` →
+  `access-control-allow-credentials: true`.
+- `--cors-allow-credentials` alone → non-zero exit, message names the conflict.
+
+## Documentation
+
+- `docs/server.md`: three new rows in the Options table, an example, and a
+  Notes bullet stating the default. `--no-csrf-check` gets documented for the
+  first time.
+- `src/web/api_docs.rs:56`: the CORS note is rewritten to describe the
+  `GET`-by-default policy and point at `--cors-origin`.
+- `docs/api.md` is **generated** from that file and guarded by
+  `tests/api_docs_md_test.rs`. Regenerate with
+  `UPDATE_API_DOCS=1 cargo test --test api_docs_md_test`; never hand-edit it.
+  Per the test's own message, cooklang.org's `scripts/sync-cli-docs.sh` is the
+  follow-up to update the website page.

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -134,6 +134,25 @@ impl CorsConfig {
     }
 }
 
+/// The `Host` header, if the request carries exactly one.
+///
+/// Deliberately ignores `Forwarded` / `X-Forwarded-Host`: those are set by
+/// whoever is on the other end of a direct connection, so a security decision
+/// must not depend on them. A deployment behind a proxy that rewrites `Host`
+/// names its public origin with `--cors-origin` instead.
+///
+/// More than one `Host` header is a malformed request (RFC 9112 §3.2 requires
+/// exactly one), and picking the first would let a raw client choose which one
+/// the guard sees — so that is treated as no host at all, which fails closed.
+pub(super) fn host_header(headers: &HeaderMap) -> Option<&str> {
+    let mut hosts = headers.get_all(header::HOST).iter();
+    let host = hosts.next()?;
+    if hosts.next().is_some() {
+        return None;
+    }
+    host.to_str().ok()
+}
+
 /// The authority this request was addressed to.
 ///
 /// Deliberately reads the `Host` header (or, for HTTP/2, the URI authority)
@@ -144,13 +163,12 @@ impl CorsConfig {
 /// deployment behind a proxy that rewrites `Host` names its public origin with
 /// `--cors-origin` instead.
 fn request_host(request: &Request) -> Option<&str> {
-    if let Some(host) = request.headers().get(header::HOST) {
-        return host.to_str().ok();
-    }
-    request
-        .uri()
-        .authority()
-        .map(|authority| authority.as_str())
+    host_header(request.headers()).or_else(|| {
+        request
+            .uri()
+            .authority()
+            .map(|authority| authority.as_str())
+    })
 }
 
 /// Whether an `Origin` value denotes the same host the request was sent to.
@@ -515,6 +533,25 @@ mod tests {
         // Nothing can then match same-origin, so writes need --cors-origin.
         let request = request_with(&[]);
         assert_eq!(request_host(&request), None);
+    }
+
+    #[test]
+    fn two_host_headers_are_treated_as_none() {
+        // Picking the first would let a raw client choose which host the guard
+        // compares against. Fail closed instead.
+        let request = request_with(&[("host", "evil.test"), ("host", "127.0.0.1:9080")]);
+        assert_eq!(request_host(&request), None);
+    }
+
+    #[test]
+    fn http2_falls_back_to_the_uri_authority() {
+        // h2 synthesises a Host header in practice, so this branch is belt and
+        // braces — but it must still be right.
+        let request = axum::http::Request::builder()
+            .uri("http://127.0.0.1:9080/api/pantry/add")
+            .body(axum::body::Body::empty())
+            .expect("valid request");
+        assert_eq!(request_host(&request), Some("127.0.0.1:9080"));
     }
 
     #[test]

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -176,6 +176,14 @@ fn request_host(request: &Request) -> Option<&str> {
 /// `Origin` is `scheme://host[:port]` while `Host` is `host[:port]`, and a
 /// browser omits the port when it is the scheme's default — so the comparison
 /// has to allow `https://a.test` to match either `a.test` or `a.test:443`.
+///
+/// The scheme is deliberately not compared. `cook server` speaks plaintext
+/// HTTP, but is routinely fronted by a TLS-terminating proxy that passes
+/// `Host` through unchanged, so `Origin: https://cook.example.com` against
+/// `Host: cook.example.com` is the *normal* proxied case — rejecting it would
+/// break those deployments. The converse reading, an `https://` page reaching
+/// a plaintext server on port 80, is blocked by browsers' mixed-content
+/// policy, so nothing reachable is given up.
 pub(super) fn origin_matches_host(origin: &str, host: &str) -> bool {
     let Ok(url) = url::Url::parse(origin) else {
         return false;
@@ -184,10 +192,13 @@ pub(super) fn origin_matches_host(origin: &str, host: &str) -> bool {
         return false;
     };
     match url.port() {
-        Some(port) => host == format!("{origin_host}:{port}"),
+        Some(port) => host.eq_ignore_ascii_case(&format!("{origin_host}:{port}")),
         None => match url.port_or_known_default() {
-            Some(default) => host == origin_host || host == format!("{origin_host}:{default}"),
-            None => host == origin_host,
+            Some(default) => {
+                host.eq_ignore_ascii_case(origin_host)
+                    || host.eq_ignore_ascii_case(&format!("{origin_host}:{default}"))
+            }
+            None => host.eq_ignore_ascii_case(origin_host),
         },
     }
 }
@@ -496,6 +507,10 @@ mod tests {
         // `Host` may or may not spell out a scheme's default port.
         assert!(origin_matches_host("https://a.test", "a.test:443"));
         assert!(origin_matches_host("http://a.test", "a.test:80"));
+        // `Url::parse` lowercases the origin's host; the Host header is not
+        // normalized for us.
+        assert!(origin_matches_host("http://A.Test:9080", "a.test:9080"));
+        assert!(origin_matches_host("http://a.test:9080", "A.TEST:9080"));
     }
 
     #[test]
@@ -504,6 +519,21 @@ mod tests {
         assert!(!origin_matches_host("http://a.test:9080", "a.test:3000"));
         assert!(!origin_matches_host("http://a.test", "b.test"));
         assert!(!origin_matches_host("not a url", "a.test"));
+    }
+
+    #[test]
+    fn the_scheme_is_not_compared() {
+        // Deliberate: see the note on `origin_matches_host`. A TLS-terminating
+        // proxy passing Host through is the normal case for an https origin.
+        assert!(origin_matches_host(
+            "https://cook.example.test",
+            "cook.example.test"
+        ));
+        // An explicit, non-default port still has to match exactly.
+        assert!(!origin_matches_host(
+            "https://cook.example.test",
+            "cook.example.test:80"
+        ));
     }
 
     fn request_with(headers: &[(&str, &str)]) -> Request {

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -67,7 +67,7 @@ impl CorsConfig {
     /// A wildcard origin means *any* page in the user's browser can reach the
     /// server, so it gets read-only access. Naming an origin is an explicit
     /// statement of trust, and unlocks the mutating routes.
-    pub fn methods(&self) -> Vec<Method> {
+    fn methods(&self) -> Vec<Method> {
         match &self.origins {
             CorsOrigins::Any => vec![Method::GET],
             CorsOrigins::List(_) => {
@@ -334,15 +334,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn layer_builds_for_wildcard() {
-        let config = CorsConfig::from_args(&[], false).expect("valid");
-        let _layer = config.layer();
+    /// tower-http's `ensure_usable_cors_rules` runs in `Layer::layer`, not in
+    /// the `CorsLayer` builder, so the layer has to be applied to a real
+    /// service for its assertions to fire.
+    fn assert_layer_applies(config: &CorsConfig) {
+        let _ = axum::Router::<()>::new()
+            .route("/", axum::routing::get(|| async {}))
+            .layer(config.layer());
     }
 
     #[test]
-    fn layer_builds_for_explicit_origins_with_credentials() {
+    fn layer_applies_for_wildcard() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert_layer_applies(&config);
+    }
+
+    #[test]
+    fn layer_applies_for_explicit_origins_with_credentials() {
         let config = CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
-        let _layer = config.layer();
+        assert_layer_applies(&config);
     }
 }

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -6,7 +6,15 @@
 //! client are unaffected by anything here.
 
 use anyhow::{bail, Result};
-use axum::http::{header, HeaderValue, Method};
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderMap, HeaderValue, Method, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use axum_extra::extract::Host;
+use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 /// Which origins may make cross-origin requests.
@@ -95,6 +103,57 @@ impl CorsConfig {
             .allow_headers([header::CONTENT_TYPE])
             .allow_credentials(self.allow_credentials)
     }
+
+    /// Whether a request with this method, these headers and this `Host` may
+    /// modify recipes.
+    ///
+    /// `allow_methods` cannot express this. `POST` is a CORS-safelisted method,
+    /// so a browser never consults `Access-Control-Allow-Methods` for it —
+    /// only a server-side check makes the wildcard default actually read-only.
+    fn allows_write(&self, method: &Method, headers: &HeaderMap, host: &str) -> bool {
+        if *method == Method::GET || *method == Method::HEAD || *method == Method::OPTIONS {
+            return true;
+        }
+        // No `Origin` means no browser. `curl` and other clients send none, and
+        // the API has no authentication for them to bypass.
+        let Some(origin) = headers.get(header::ORIGIN) else {
+            return true;
+        };
+        let Ok(origin) = origin.to_str() else {
+            return false;
+        };
+        origin_matches_host(origin, host) || self.lists_origin(origin)
+    }
+
+    fn lists_origin(&self, origin: &str) -> bool {
+        match &self.origins {
+            CorsOrigins::Any => false,
+            CorsOrigins::List(list) => list
+                .iter()
+                .any(|listed| listed.as_bytes() == origin.as_bytes()),
+        }
+    }
+}
+
+/// Whether an `Origin` value denotes the same host the request was sent to.
+///
+/// `Origin` is `scheme://host[:port]` while `Host` is `host[:port]`, and a
+/// browser omits the port when it is the scheme's default — so the comparison
+/// has to allow `https://a.test` to match either `a.test` or `a.test:443`.
+pub(super) fn origin_matches_host(origin: &str, host: &str) -> bool {
+    let Ok(url) = url::Url::parse(origin) else {
+        return false;
+    };
+    let Some(origin_host) = url.host_str() else {
+        return false;
+    };
+    match url.port() {
+        Some(port) => host == format!("{origin_host}:{port}"),
+        None => match url.port_or_known_default() {
+            Some(default) => host == origin_host || host == format!("{origin_host}:{default}"),
+            None => host == origin_host,
+        },
+    }
 }
 
 /// Parses one `--cors-origin` value.
@@ -170,6 +229,36 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
 
     HeaderValue::from_str(origin)
         .map_err(|e| anyhow::anyhow!("invalid --cors-origin {origin:?}: {e}"))
+}
+
+/// Rejects cross-origin requests that would modify recipes.
+///
+/// Applied inside the CORS layer, so tower-http has already answered any
+/// `OPTIONS` preflight before this runs.
+pub async fn write_guard(
+    State(config): State<Arc<CorsConfig>>,
+    Host(host): Host,
+    request: Request,
+    next: Next,
+) -> Response {
+    if config.allows_write(request.method(), request.headers(), &host) {
+        return next.run(request).await;
+    }
+
+    tracing::warn!(
+        method = %request.method(),
+        path = %request.uri().path(),
+        "refused a cross-origin request that would modify recipes"
+    );
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "Cross-origin requests may not modify recipes. Start the server with \
+                      --cors-origin <ORIGIN> to allow this origin, or --no-csrf-check to \
+                      disable this check."
+        })),
+    )
+        .into_response()
 }
 
 #[cfg(test)]
@@ -353,5 +442,94 @@ mod tests {
     fn layer_applies_for_explicit_origins_with_credentials() {
         let config = CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
         assert_layer_applies(&config);
+    }
+
+    fn headers_with_origin(origin: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_str(origin).expect("valid"),
+        );
+        headers
+    }
+
+    #[test]
+    fn origin_matches_its_own_host() {
+        assert!(origin_matches_host("http://a.test:9080", "a.test:9080"));
+        assert!(origin_matches_host("http://a.test", "a.test"));
+        // `Host` may or may not spell out a scheme's default port.
+        assert!(origin_matches_host("https://a.test", "a.test:443"));
+        assert!(origin_matches_host("http://a.test", "a.test:80"));
+    }
+
+    #[test]
+    fn origin_on_a_different_port_is_not_the_same_host() {
+        assert!(!origin_matches_host("http://a.test:9080", "a.test"));
+        assert!(!origin_matches_host("http://a.test:9080", "a.test:3000"));
+        assert!(!origin_matches_host("http://a.test", "b.test"));
+        assert!(!origin_matches_host("not a url", "a.test"));
+    }
+
+    #[test]
+    fn reads_are_always_allowed() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        for method in [Method::GET, Method::HEAD, Method::OPTIONS] {
+            assert!(
+                config.allows_write(&method, &headers_with_origin("http://evil.test"), "a.test"),
+                "{method} must pass the guard"
+            );
+        }
+    }
+
+    #[test]
+    fn a_request_without_an_origin_is_not_a_browser() {
+        // curl and every other non-browser client. The API has no auth, so
+        // rejecting these would break integrations and protect nothing.
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert!(config.allows_write(&Method::POST, &HeaderMap::new(), "a.test"));
+    }
+
+    #[test]
+    fn same_origin_writes_are_allowed() {
+        // This is the web UI's own POST.
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert!(config.allows_write(
+            &Method::POST,
+            &headers_with_origin("http://a.test:9080"),
+            "a.test:9080"
+        ));
+    }
+
+    #[test]
+    fn cross_origin_writes_are_refused_under_the_wildcard_default() {
+        // The hole this guard exists to close: POST is CORS-safelisted, so
+        // Access-Control-Allow-Methods: GET does not stop it.
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        for method in [Method::POST, Method::PUT, Method::DELETE] {
+            assert!(
+                !config.allows_write(
+                    &method,
+                    &headers_with_origin("http://evil.test"),
+                    "a.test:9080"
+                ),
+                "cross-origin {method} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn a_listed_origin_may_write() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://app.test:3000"]), false).expect("valid");
+        assert!(config.allows_write(
+            &Method::POST,
+            &headers_with_origin("http://app.test:3000"),
+            "a.test:9080"
+        ));
+        assert!(!config.allows_write(
+            &Method::POST,
+            &headers_with_origin("http://evil.test"),
+            "a.test:9080"
+        ));
     }
 }

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -13,7 +13,6 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use axum_extra::extract::Host;
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
@@ -135,6 +134,25 @@ impl CorsConfig {
     }
 }
 
+/// The authority this request was addressed to.
+///
+/// Deliberately reads the `Host` header (or, for HTTP/2, the URI authority)
+/// rather than `Forwarded` / `X-Forwarded-Host`. Those are set by whoever is
+/// on the other end of a direct connection, so a security decision must not
+/// depend on them — `Origin: http://evil.test` plus
+/// `X-Forwarded-Host: evil.test` would otherwise look same-origin. A
+/// deployment behind a proxy that rewrites `Host` names its public origin with
+/// `--cors-origin` instead.
+fn request_host(request: &Request) -> Option<&str> {
+    if let Some(host) = request.headers().get(header::HOST) {
+        return host.to_str().ok();
+    }
+    request
+        .uri()
+        .authority()
+        .map(|authority| authority.as_str())
+}
+
 /// Whether an `Origin` value denotes the same host the request was sent to.
 ///
 /// `Origin` is `scheme://host[:port]` while `Host` is `host[:port]`, and a
@@ -237,11 +255,11 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
 /// `OPTIONS` preflight before this runs.
 pub async fn write_guard(
     State(config): State<Arc<CorsConfig>>,
-    Host(host): Host,
     request: Request,
     next: Next,
 ) -> Response {
-    if config.allows_write(request.method(), request.headers(), &host) {
+    let host = request_host(&request).unwrap_or_default();
+    if config.allows_write(request.method(), request.headers(), host) {
         return next.run(request).await;
     }
 
@@ -468,6 +486,35 @@ mod tests {
         assert!(!origin_matches_host("http://a.test:9080", "a.test:3000"));
         assert!(!origin_matches_host("http://a.test", "b.test"));
         assert!(!origin_matches_host("not a url", "a.test"));
+    }
+
+    fn request_with(headers: &[(&str, &str)]) -> Request {
+        let mut builder = axum::http::Request::builder().uri("/api/pantry/add");
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        builder
+            .body(axum::body::Body::empty())
+            .expect("valid request")
+    }
+
+    #[test]
+    fn host_comes_from_the_host_header_not_a_forwarded_one() {
+        // `Origin: http://evil.test` plus `X-Forwarded-Host: evil.test` must
+        // not read as same-origin: both are attacker-supplied.
+        let request = request_with(&[
+            ("host", "127.0.0.1:9080"),
+            ("x-forwarded-host", "evil.test"),
+            ("forwarded", "host=evil.test"),
+        ]);
+        assert_eq!(request_host(&request), Some("127.0.0.1:9080"));
+    }
+
+    #[test]
+    fn a_request_with_no_host_at_all_has_no_authority() {
+        // Nothing can then match same-origin, so writes need --cors-origin.
+        let request = request_with(&[]);
+        assert_eq!(request_host(&request), None);
     }
 
     #[test]

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -32,7 +32,7 @@ impl CorsConfig {
     /// `origins` is the raw repeated flag; empty means the flag was not given.
     pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self> {
         let wildcard = origins.iter().any(|o| o == "*");
-        if wildcard && origins.len() > 1 {
+        if wildcard && origins.iter().any(|o| o != "*") {
             bail!(
                 "--cors-origin '*' cannot be combined with explicit origins; \
                  pass either '*' or a list of origins, not both"
@@ -49,7 +49,7 @@ impl CorsConfig {
             CorsOrigins::List(parsed)
         };
 
-        if allow_credentials && origins == CorsOrigins::Any {
+        if allow_credentials && matches!(origins, CorsOrigins::Any) {
             bail!(
                 "--cors-allow-credentials requires explicit --cors-origin values; \
                  browsers reject credentialed requests against a wildcard origin"
@@ -79,9 +79,11 @@ impl CorsConfig {
 
 /// Parses one `--cors-origin` value.
 ///
-/// A browser sends a bare origin — scheme, host, optional port — in the
-/// `Origin` header. Anything richer (a path, a trailing slash) would compare
-/// unequal and silently never match, so it is rejected up front instead.
+/// A browser sends a bare origin — lowercase scheme, lowercase host, optional
+/// numeric port — in the `Origin` header, and tower-http compares it byte for
+/// byte. Anything richer or differently cased would never match and would fail
+/// silently at request time, with no diagnostic anywhere, so it is rejected
+/// here instead.
 fn parse_origin(origin: &str) -> Result<HeaderValue> {
     let Some((scheme, rest)) = origin.split_once("://") else {
         bail!("invalid --cors-origin {origin:?}: expected a scheme, e.g. http://localhost:3000");
@@ -89,12 +91,42 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
     if scheme.is_empty() || rest.is_empty() {
         bail!("invalid --cors-origin {origin:?}: expected scheme://host[:port]");
     }
-    if rest.contains('/') {
+    // Schemes are ASCII, and browsers lowercase them. `chrome-extension` and
+    // other non-http schemes are legitimate `Origin` values, so the rule is a
+    // character set rather than an allowlist.
+    if !scheme
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '+' | '-' | '.'))
+    {
         bail!(
-            "invalid --cors-origin {origin:?}: an origin has no path or trailing slash, \
+            "invalid --cors-origin {origin:?}: {scheme:?} is not a valid lowercase scheme, \
              e.g. http://localhost:3000"
         );
     }
+
+    let (host, port) = match rest.split_once(':') {
+        Some((host, port)) => (host, Some(port)),
+        None => (rest, None),
+    };
+    if host.is_empty() {
+        bail!("invalid --cors-origin {origin:?}: expected scheme://host[:port]");
+    }
+    if let Some(bad) = host
+        .chars()
+        .find(|c| c.is_whitespace() || c.is_ascii_uppercase() || matches!(c, '/' | '?' | '#' | '@'))
+    {
+        bail!(
+            "invalid --cors-origin {origin:?}: a browser sends a bare lowercase origin, \
+             so {bad:?} can never match; expected scheme://host[:port], \
+             e.g. http://localhost:3000"
+        );
+    }
+    if let Some(port) = port {
+        if port.parse::<u16>().is_err() {
+            bail!("invalid --cors-origin {origin:?}: {port:?} is not a valid port number");
+        }
+    }
+
     HeaderValue::from_str(origin)
         .map_err(|e| anyhow::anyhow!("invalid --cors-origin {origin:?}: {e}"))
 }
@@ -118,6 +150,7 @@ mod tests {
     fn explicit_wildcard_is_any() {
         let config = CorsConfig::from_args(&origins(&["*"]), false).expect("valid");
         assert_eq!(config.origins, CorsOrigins::Any);
+        assert_eq!(config.methods(), vec![Method::GET]);
     }
 
     #[test]
@@ -161,12 +194,19 @@ mod tests {
             err.to_string().contains("--cors-origin"),
             "error must point at the fix: {err}"
         );
+
+        // The spelling a user actually types, and the one that would panic
+        // tower-http at request time if this guard ever stopped firing.
+        let err = CorsConfig::from_args(&origins(&["*"]), true).expect_err("must reject");
+        assert!(
+            err.to_string().contains("--cors-origin"),
+            "error must point at the fix: {err}"
+        );
     }
 
     #[test]
     fn credentials_with_explicit_origins_is_allowed() {
-        let config =
-            CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
+        let config = CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
         assert!(config.allow_credentials);
     }
 
@@ -182,11 +222,57 @@ mod tests {
 
     #[test]
     fn origin_without_scheme_is_rejected() {
-        CorsConfig::from_args(&origins(&["a.test"]), false).expect_err("must reject");
+        let err = CorsConfig::from_args(&origins(&["a.test"]), false).expect_err("must reject");
+        assert!(
+            err.to_string().contains("expected a scheme"),
+            "unhelpful error: {err}"
+        );
     }
 
     #[test]
     fn empty_origin_is_rejected() {
-        CorsConfig::from_args(&origins(&[""]), false).expect_err("must reject");
+        let err = CorsConfig::from_args(&origins(&[""]), false).expect_err("must reject");
+        assert!(
+            err.to_string().contains("expected a scheme"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    #[test]
+    fn origins_that_could_never_match_a_browser_are_rejected() {
+        // tower-http compares the `Origin` header byte for byte, and browsers
+        // send a bare lowercase origin. Each of these would start the server
+        // happily and then never match anything.
+        for bad in [
+            "HTTP://A.test",
+            "http://a.test ",
+            " http://a.test",
+            "http://a.test\t",
+            "http://a.test/foo",
+            "http://a.test?x=1",
+            "http://a.test#frag",
+            "http://user:pass@a.test",
+            "http://a.test:notaport",
+            "http://a.test:99999",
+            "*://a.test",
+            "://a.test",
+        ] {
+            CorsConfig::from_args(&origins(&[bad]), false)
+                .expect_err(&format!("{bad:?} must be rejected"));
+        }
+    }
+
+    #[test]
+    fn non_http_schemes_are_accepted() {
+        // Browser extensions and desktop shells send these as `Origin`.
+        for good in [
+            "chrome-extension://abcdefghijklmnop",
+            "moz-extension://abcdefghijklmnop",
+            "tauri://localhost",
+            "https://a.test:8443",
+        ] {
+            CorsConfig::from_args(&origins(&[good]), false)
+                .unwrap_or_else(|e| panic!("{good:?} must be accepted: {e}"));
+        }
     }
 }

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -119,22 +119,29 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
 
     // An IPv6 host is bracketed and full of colons, so the port can only be
     // split off after the closing bracket.
-    let port = if let Some(rest) = rest.strip_prefix('[') {
-        let Some((_host, after)) = rest.split_once(']') else {
+    let (host, port) = if let Some(rest) = rest.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
             bail!(
                 "invalid --cors-origin {origin:?}: unterminated IPv6 host, e.g. http://[::1]:3000"
             );
         };
-        match after {
+        let port = match after {
             "" => None,
             _ => Some(after.strip_prefix(':').ok_or_else(|| {
                 anyhow::anyhow!("invalid --cors-origin {origin:?}: expected scheme://host[:port]")
             })?),
-        }
+        };
+        (host, port)
     } else {
-        rest.rsplit_once(':').map(|(_host, port)| port)
+        match rest.rsplit_once(':') {
+            Some((host, port)) => (host, Some(port)),
+            None => (rest, None),
+        }
     };
 
+    if host.is_empty() {
+        bail!("invalid --cors-origin {origin:?}: missing host, expected scheme://host[:port]");
+    }
     if let Some(port) = port {
         if port.parse::<u16>().is_err() {
             bail!("invalid --cors-origin {origin:?}: {port:?} is not a valid port number");
@@ -272,6 +279,8 @@ mod tests {
             "://a.test",
             "http://[::1",
             "http://[::1]x",
+            "http://[]",
+            "http://:3000",
         ] {
             CorsConfig::from_args(&origins(&[bad]), false)
                 .expect_err(&format!("{bad:?} must be rejected"));

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -1,0 +1,192 @@
+//! CORS policy for `cook server`, built from the `--cors-origin` and
+//! `--cors-allow-credentials` flags.
+//!
+//! CORS is enforced by browsers only, so this governs what cross-origin web
+//! pages may do with the API. The web UI itself, `curl`, and every non-browser
+//! client are unaffected by anything here.
+
+use anyhow::{bail, Result};
+use axum::http::{header, HeaderValue, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+/// Which origins may make cross-origin requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorsOrigins {
+    /// `--cors-origin '*'`, or no `--cors-origin` at all. Read-only: see
+    /// [`CorsConfig::methods`].
+    Any,
+    /// One or more explicit origins, in the order given on the command line.
+    List(Vec<HeaderValue>),
+}
+
+/// A validated CORS policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorsConfig {
+    origins: CorsOrigins,
+    allow_credentials: bool,
+}
+
+impl CorsConfig {
+    /// Validates a `--cors-origin` / `--cors-allow-credentials` combination.
+    ///
+    /// `origins` is the raw repeated flag; empty means the flag was not given.
+    pub fn from_args(origins: &[String], allow_credentials: bool) -> Result<Self> {
+        let wildcard = origins.iter().any(|o| o == "*");
+        if wildcard && origins.len() > 1 {
+            bail!(
+                "--cors-origin '*' cannot be combined with explicit origins; \
+                 pass either '*' or a list of origins, not both"
+            );
+        }
+
+        let origins = if origins.is_empty() || wildcard {
+            CorsOrigins::Any
+        } else {
+            let parsed = origins
+                .iter()
+                .map(|origin| parse_origin(origin))
+                .collect::<Result<Vec<_>>>()?;
+            CorsOrigins::List(parsed)
+        };
+
+        if allow_credentials && origins == CorsOrigins::Any {
+            bail!(
+                "--cors-allow-credentials requires explicit --cors-origin values; \
+                 browsers reject credentialed requests against a wildcard origin"
+            );
+        }
+
+        Ok(Self {
+            origins,
+            allow_credentials,
+        })
+    }
+
+    /// The methods this policy allows cross-origin.
+    ///
+    /// A wildcard origin means *any* page in the user's browser can reach the
+    /// server, so it gets read-only access. Naming an origin is an explicit
+    /// statement of trust, and unlocks the mutating routes.
+    pub fn methods(&self) -> Vec<Method> {
+        match &self.origins {
+            CorsOrigins::Any => vec![Method::GET],
+            CorsOrigins::List(_) => {
+                vec![Method::GET, Method::POST, Method::PUT, Method::DELETE]
+            }
+        }
+    }
+}
+
+/// Parses one `--cors-origin` value.
+///
+/// A browser sends a bare origin — scheme, host, optional port — in the
+/// `Origin` header. Anything richer (a path, a trailing slash) would compare
+/// unequal and silently never match, so it is rejected up front instead.
+fn parse_origin(origin: &str) -> Result<HeaderValue> {
+    let Some((scheme, rest)) = origin.split_once("://") else {
+        bail!("invalid --cors-origin {origin:?}: expected a scheme, e.g. http://localhost:3000");
+    };
+    if scheme.is_empty() || rest.is_empty() {
+        bail!("invalid --cors-origin {origin:?}: expected scheme://host[:port]");
+    }
+    if rest.contains('/') {
+        bail!(
+            "invalid --cors-origin {origin:?}: an origin has no path or trailing slash, \
+             e.g. http://localhost:3000"
+        );
+    }
+    HeaderValue::from_str(origin)
+        .map_err(|e| anyhow::anyhow!("invalid --cors-origin {origin:?}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origins(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_flag_defaults_to_any() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert_eq!(config.origins, CorsOrigins::Any);
+        assert!(!config.allow_credentials);
+    }
+
+    #[test]
+    fn explicit_wildcard_is_any() {
+        let config = CorsConfig::from_args(&origins(&["*"]), false).expect("valid");
+        assert_eq!(config.origins, CorsOrigins::Any);
+    }
+
+    #[test]
+    fn any_allows_only_get() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        assert_eq!(config.methods(), vec![Method::GET]);
+    }
+
+    #[test]
+    fn explicit_origins_keep_order_and_allow_mutation() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://a.test", "https://b.test:8443"]), false)
+                .expect("valid");
+        assert_eq!(
+            config.origins,
+            CorsOrigins::List(vec![
+                HeaderValue::from_static("http://a.test"),
+                HeaderValue::from_static("https://b.test:8443"),
+            ])
+        );
+        assert_eq!(
+            config.methods(),
+            vec![Method::GET, Method::POST, Method::PUT, Method::DELETE]
+        );
+    }
+
+    #[test]
+    fn wildcard_mixed_with_explicit_origin_is_rejected() {
+        let err = CorsConfig::from_args(&origins(&["*", "http://a.test"]), false)
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("cannot be combined"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    #[test]
+    fn credentials_with_wildcard_is_rejected() {
+        let err = CorsConfig::from_args(&[], true).expect_err("must reject");
+        assert!(
+            err.to_string().contains("--cors-origin"),
+            "error must point at the fix: {err}"
+        );
+    }
+
+    #[test]
+    fn credentials_with_explicit_origins_is_allowed() {
+        let config =
+            CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
+        assert!(config.allow_credentials);
+    }
+
+    #[test]
+    fn origin_with_trailing_slash_is_rejected() {
+        let err =
+            CorsConfig::from_args(&origins(&["http://a.test/"]), false).expect_err("must reject");
+        assert!(
+            err.to_string().contains("http://a.test/"),
+            "error must name the bad origin: {err}"
+        );
+    }
+
+    #[test]
+    fn origin_without_scheme_is_rejected() {
+        CorsConfig::from_args(&origins(&["a.test"]), false).expect_err("must reject");
+    }
+
+    #[test]
+    fn empty_origin_is_rejected() {
+        CorsConfig::from_args(&origins(&[""]), false).expect_err("must reject");
+    }
+}

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -104,14 +104,9 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
         );
     }
 
-    let (host, port) = match rest.split_once(':') {
-        Some((host, port)) => (host, Some(port)),
-        None => (rest, None),
-    };
-    if host.is_empty() {
-        bail!("invalid --cors-origin {origin:?}: expected scheme://host[:port]");
-    }
-    if let Some(bad) = host
+    // Check the whole remainder before splitting off a port, so userinfo and
+    // other extras are reported as what they are rather than as a bad port.
+    if let Some(bad) = rest
         .chars()
         .find(|c| c.is_whitespace() || c.is_ascii_uppercase() || matches!(c, '/' | '?' | '#' | '@'))
     {
@@ -121,6 +116,25 @@ fn parse_origin(origin: &str) -> Result<HeaderValue> {
              e.g. http://localhost:3000"
         );
     }
+
+    // An IPv6 host is bracketed and full of colons, so the port can only be
+    // split off after the closing bracket.
+    let port = if let Some(rest) = rest.strip_prefix('[') {
+        let Some((_host, after)) = rest.split_once(']') else {
+            bail!(
+                "invalid --cors-origin {origin:?}: unterminated IPv6 host, e.g. http://[::1]:3000"
+            );
+        };
+        match after {
+            "" => None,
+            _ => Some(after.strip_prefix(':').ok_or_else(|| {
+                anyhow::anyhow!("invalid --cors-origin {origin:?}: expected scheme://host[:port]")
+            })?),
+        }
+    } else {
+        rest.rsplit_once(':').map(|(_host, port)| port)
+    };
+
     if let Some(port) = port {
         if port.parse::<u16>().is_err() {
             bail!("invalid --cors-origin {origin:?}: {port:?} is not a valid port number");
@@ -256,6 +270,8 @@ mod tests {
             "http://a.test:99999",
             "*://a.test",
             "://a.test",
+            "http://[::1",
+            "http://[::1]x",
         ] {
             CorsConfig::from_args(&origins(&[bad]), false)
                 .expect_err(&format!("{bad:?} must be rejected"));
@@ -263,16 +279,29 @@ mod tests {
     }
 
     #[test]
-    fn non_http_schemes_are_accepted() {
-        // Browser extensions and desktop shells send these as `Origin`.
+    fn unusual_but_valid_origins_are_accepted() {
+        // Browser extensions, desktop shells, and IPv6 hosts are legitimate
+        // `Origin` values.
         for good in [
             "chrome-extension://abcdefghijklmnop",
             "moz-extension://abcdefghijklmnop",
             "tauri://localhost",
             "https://a.test:8443",
+            "http://[::1]:3000",
+            "http://[::1]",
         ] {
             CorsConfig::from_args(&origins(&[good]), false)
                 .unwrap_or_else(|e| panic!("{good:?} must be accepted: {e}"));
         }
+    }
+
+    #[test]
+    fn userinfo_is_reported_as_userinfo_not_as_a_bad_port() {
+        let err = CorsConfig::from_args(&origins(&["http://user:pass@a.test"]), false)
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("bare lowercase origin"),
+            "userinfo must not be misreported as a bad port: {err}"
+        );
     }
 }

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -75,6 +75,26 @@ impl CorsConfig {
             }
         }
     }
+
+    /// Builds the tower-http layer for this policy.
+    ///
+    /// `content-type` is always allowed: without it a cross-origin JSON `POST`
+    /// fails preflight no matter what the origin setting is, so there is
+    /// nothing here worth making configurable. The CORS-safelisted request
+    /// headers (`Accept`, `Accept-Language`, `Content-Language`) need no entry
+    /// — browsers permit them regardless.
+    pub fn layer(&self) -> CorsLayer {
+        let allow_origin = match &self.origins {
+            CorsOrigins::Any => AllowOrigin::any(),
+            CorsOrigins::List(list) => AllowOrigin::list(list.iter().cloned()),
+        };
+
+        CorsLayer::new()
+            .allow_origin(allow_origin)
+            .allow_methods(self.methods())
+            .allow_headers([header::CONTENT_TYPE])
+            .allow_credentials(self.allow_credentials)
+    }
 }
 
 /// Parses one `--cors-origin` value.
@@ -312,5 +332,17 @@ mod tests {
             err.to_string().contains("bare lowercase origin"),
             "userinfo must not be misreported as a bad port: {err}"
         );
+    }
+
+    #[test]
+    fn layer_builds_for_wildcard() {
+        let config = CorsConfig::from_args(&[], false).expect("valid");
+        let _layer = config.layer();
+    }
+
+    #[test]
+    fn layer_builds_for_explicit_origins_with_credentials() {
+        let config = CorsConfig::from_args(&origins(&["http://a.test"]), true).expect("valid");
+        let _layer = config.layer();
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -113,12 +113,15 @@ pub struct ServerArgs {
     #[arg(long, default_value_t = false)]
     cors_allow_credentials: bool,
 
-    /// Enable cors verification
+    /// Disable same-origin enforcement on requests that modify recipes
     ///
-    /// When enabled, the POST /new path require a seemless
-    /// Origin and Host header.
-    #[arg(long = "no-cors", action = clap::ArgAction::SetFalse)]
-    cors: bool,
+    /// By default a request is rejected unless its Origin matches the Host it
+    /// was sent to, or is named by --cors-origin. This has nothing to do with
+    /// the cross-origin read policy the other --cors-* flags configure. Use it
+    /// only when a reverse proxy rewrites Host in a way that cannot be
+    /// expressed with --cors-origin. The former spelling --no-cors still works.
+    #[arg(long = "no-csrf-check", alias = "no-cors", action = clap::ArgAction::SetFalse)]
+    csrf_check: bool,
 }
 
 impl ServerArgs {
@@ -334,7 +337,7 @@ fn build_state(ctx: Context, args: ServerArgs) -> Result<Arc<AppState>> {
         aisle_path,
         pantry_path,
         url_prefix,
-        cors: args.cors,
+        csrf_check: args.csrf_check,
         checked_log_lock: Arc::new(tokio::sync::Mutex::new(())),
         shopping_list_events,
         #[cfg(feature = "sync")]
@@ -383,7 +386,9 @@ pub struct AppState {
     pub aisle_path: Option<Utf8PathBuf>,
     pub pantry_path: Option<Utf8PathBuf>,
     pub url_prefix: String,
-    pub cors: bool,
+    /// When true, requests that modify recipes must be same-origin or come
+    /// from a `--cors-origin`. Cleared by `--no-csrf-check`.
+    pub csrf_check: bool,
     /// Serializes access to `.shopping-checked` within this process.
     /// File-level `flock` doesn't prevent two tasks in the *same* process
     /// from racing on the file (the kernel treats them as one lock owner),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -100,9 +100,11 @@ pub struct ServerArgs {
     /// Origin allowed to make cross-origin browser requests (repeatable)
     ///
     /// Pass once per origin, e.g. --cors-origin http://localhost:3000. Use "*"
-    /// for any origin, which is the default. A wildcard origin allows GET
-    /// only; naming explicit origins also allows POST, PUT and DELETE.
-    /// "*" cannot be combined with explicit origins.
+    /// for any origin, which is the default. Under a wildcard origin the
+    /// server answers cross-origin reads but refuses cross-origin writes with
+    /// 403; naming explicit origins lets those origins write too. "*" cannot
+    /// be combined with explicit origins. Requests with no Origin header --
+    /// curl and other non-browser clients -- are never affected.
     #[arg(long, value_name = "ORIGIN")]
     cors_origin: Vec<String>,
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -214,9 +214,13 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
 
     // Capture url_prefix before state is consumed by with_state.
     let url_prefix_for_features = state.url_prefix.clone();
+    let csrf_check = state.csrf_check;
 
     #[cfg(feature = "sync")]
     let state_for_shutdown = state.clone();
+
+    let cors_layer = cors.layer();
+    let cors = Arc::new(cors);
 
     let app = app
         .with_state(state)
@@ -227,8 +231,20 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
         ))
         .layer(axum::middleware::from_fn(
             crate::web::language::language_middleware,
+        ));
+
+    // Inside the CORS layer, so preflights are answered before it runs.
+    // `--no-csrf-check` omits it entirely.
+    let app = if csrf_check {
+        app.layer(axum::middleware::from_fn_with_state(
+            cors,
+            cors::write_guard,
         ))
-        .layer(cors.layer());
+    } else {
+        app
+    };
+
+    let app = app.layer(cors_layer);
 
     let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => listener,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -103,14 +103,14 @@ pub struct ServerArgs {
     /// for any origin, which is the default. A wildcard origin allows GET
     /// only; naming explicit origins also allows POST, PUT and DELETE.
     /// "*" cannot be combined with explicit origins.
-    #[arg(long = "cors-origin", value_name = "ORIGIN")]
+    #[arg(long, value_name = "ORIGIN")]
     cors_origin: Vec<String>,
 
     /// Allow cross-origin requests to carry cookies and credentials
     ///
     /// Requires at least one explicit --cors-origin; browsers reject
     /// credentialed requests against a wildcard origin.
-    #[arg(long = "cors-allow-credentials", default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     cors_allow_credentials: bool,
 
     /// Enable cors verification

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,7 +34,7 @@ use anyhow::{bail, Context as _, Result};
 use axum::{
     body::Body,
     extract::{DefaultBodyLimit, Path},
-    http::{header, HeaderValue, Method, Response, StatusCode},
+    http::{header, Response, StatusCode},
     routing::{get, post},
     Router,
 };
@@ -43,7 +43,7 @@ use clap::Args;
 #[cfg(feature = "sync")]
 use std::sync::Mutex;
 use std::{net::IpAddr, net::SocketAddr, sync::Arc};
-use tower_http::{cors::CorsLayer, services::ServeDir};
+use tower_http::services::ServeDir;
 use tracing::{error, info};
 
 mod cors;
@@ -97,6 +97,22 @@ pub struct ServerArgs {
     #[arg(long, default_value_t = false)]
     open: bool,
 
+    /// Origin allowed to make cross-origin browser requests (repeatable)
+    ///
+    /// Pass once per origin, e.g. --cors-origin http://localhost:3000. Use "*"
+    /// for any origin, which is the default. A wildcard origin allows GET
+    /// only; naming explicit origins also allows POST, PUT and DELETE.
+    /// "*" cannot be combined with explicit origins.
+    #[arg(long = "cors-origin", value_name = "ORIGIN")]
+    cors_origin: Vec<String>,
+
+    /// Allow cross-origin requests to carry cookies and credentials
+    ///
+    /// Requires at least one explicit --cors-origin; browsers reject
+    /// credentialed requests against a wildcard origin.
+    #[arg(long = "cors-allow-credentials", default_value_t = false)]
+    cors_allow_credentials: bool,
+
     /// Enable cors verification
     ///
     /// When enabled, the POST /new path require a seemless
@@ -120,6 +136,10 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
     };
     let addr = SocketAddr::from((addr, args.port));
     let open = args.open;
+
+    // Validate before binding or printing anything, so a bad flag combination
+    // fails immediately rather than after the "Listening on ..." banner.
+    let cors = cors::CorsConfig::from_args(&args.cors_origin, args.cors_allow_credentials)?;
 
     let state = build_state(ctx, args)?;
 
@@ -205,11 +225,7 @@ pub async fn run(ctx: Context, args: ServerArgs) -> Result<()> {
         .layer(axum::middleware::from_fn(
             crate::web::language::language_middleware,
         ))
-        .layer(
-            CorsLayer::new()
-                .allow_origin("*".parse::<HeaderValue>().unwrap())
-                .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]),
-        );
+        .layer(cors.layer());
 
     let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => listener,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -46,6 +46,7 @@ use std::{net::IpAddr, net::SocketAddr, sync::Arc};
 use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{error, info};
 
+mod cors;
 mod fs_atomic;
 mod handlers;
 mod lsp_bridge;

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -254,43 +254,23 @@ fn new_page_error(prefix: &str, error: &str, filename: &str) -> axum::response::
 
 /// Validates that the request originated from the same host (CSRF protection)
 fn validate_same_origin(headers: &HeaderMap, host: &str) -> bool {
-    // Check Origin header first (preferred for CSRF protection)
+    // Origin first: it is the header a browser always sends on a form POST,
+    // and the one an attacker cannot forge.
     if let Some(origin) = headers.get(header::ORIGIN) {
-        if let Ok(origin_str) = origin.to_str() {
-            // Origin format is scheme://host[:port]
-            if let Ok(origin_url) = url::Url::parse(origin_str) {
-                if let Some(origin_host) = origin_url.host_str() {
-                    let origin_with_port = if let Some(port) = origin_url.port() {
-                        format!("{}:{}", origin_host, port)
-                    } else {
-                        origin_host.to_string()
-                    };
-                    return origin_with_port == host || origin_host == host;
-                }
-            }
-        }
-        return false;
+        return origin
+            .to_str()
+            .is_ok_and(|origin| super::cors::origin_matches_host(origin, host));
     }
 
-    // Fallback to Referer header (less reliable but better than nothing)
+    // Referer is less reliable but better than nothing.
     if let Some(referer) = headers.get(header::REFERER) {
-        if let Ok(referer_str) = referer.to_str() {
-            if let Ok(referer_url) = url::Url::parse(referer_str) {
-                if let Some(referer_host) = referer_url.host_str() {
-                    let referer_with_port = if let Some(port) = referer_url.port() {
-                        format!("{}:{}", referer_host, port)
-                    } else {
-                        referer_host.to_string()
-                    };
-                    return referer_with_port == host || referer_host == host;
-                }
-            }
-        }
-        return false;
+        return referer
+            .to_str()
+            .is_ok_and(|referer| super::cors::origin_matches_host(referer, host));
     }
 
-    // No Origin or Referer header - reject for safety
-    // (though browsers should always send one for form submissions)
+    // Neither header: reject. Browsers always send one for a form submission,
+    // unlike the API, where a missing Origin just means a non-browser client.
     false
 }
 

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -276,12 +276,13 @@ fn validate_same_origin(headers: &HeaderMap, host: &str) -> bool {
 
 async fn create_recipe(
     State(state): State<Arc<AppState>>,
-    Host(host): Host,
     headers: HeaderMap,
     Form(form): Form<NewRecipeForm>,
 ) -> impl IntoResponse {
-    // CSRF protection: verify request came from same origin
-    if state.csrf_check && !validate_same_origin(&headers, &host) {
+    // The raw `Host` header, not axum-extra's `Host` extractor: that one
+    // prefers `X-Forwarded-Host`, which any client can set.
+    let host = super::cors::host_header(&headers).unwrap_or_default();
+    if state.csrf_check && !validate_same_origin(&headers, host) {
         tracing::warn!("CSRF validation failed for create_recipe request");
         return (StatusCode::FORBIDDEN, "Invalid request origin").into_response();
     }

--- a/src/server/ui.rs
+++ b/src/server/ui.rs
@@ -301,7 +301,7 @@ async fn create_recipe(
     Form(form): Form<NewRecipeForm>,
 ) -> impl IntoResponse {
     // CSRF protection: verify request came from same origin
-    if state.cors && !validate_same_origin(&headers, &host) {
+    if state.csrf_check && !validate_same_origin(&headers, &host) {
         tracing::warn!("CSRF validation failed for create_recipe request");
         return (StatusCode::FORBIDDEN, "Invalid request origin").into_response();
     }

--- a/src/web/api_docs.rs
+++ b/src/web/api_docs.rs
@@ -54,7 +54,11 @@ pub fn preamble() -> ApiPreamble {
             ),
             note(
                 "CORS",
-                "All origins are allowed, for the methods GET, POST, PUT and DELETE.",
+                "`GET` is allowed from any origin. A cross-origin request that would modify \
+                 recipes is refused with `403` unless the server was started with a matching \
+                 `--cors-origin <ORIGIN>`. Requests with no `Origin` header — `curl` and other \
+                 non-browser clients — are unaffected. `content-type` is always an allowed \
+                 request header.",
             ),
             note("Request size limit", "1 MB."),
             note(
@@ -71,6 +75,11 @@ pub fn preamble() -> ApiPreamble {
                 "400",
                 "malformed input: an invalid path, a bad query parameter, or a recipe that \
                  failed to parse.",
+            ),
+            note(
+                "403",
+                "a cross-origin request tried to modify recipes. Start the server with \
+                 `--cors-origin <ORIGIN>` to allow that origin.",
             ),
             note(
                 "404",

--- a/tests/cors_test.rs
+++ b/tests/cors_test.rs
@@ -60,13 +60,36 @@ fn free_port() -> u16 {
     listener.local_addr().expect("local addr").port()
 }
 
-/// One minimal recipe, just enough for the server to have something to scan.
+/// One minimal recipe, just enough for the server to have something to scan,
+/// plus a pantry config so `POST /api/pantry/add` has somewhere to write and
+/// a permitted write returns a real success instead of `404` (no pantry
+/// configured) either way.
 fn write_fixture(dir: &TempDir) {
     std::fs::write(
         dir.path().join("Recipe.cook"),
         "Mix @flour{100%g} and @water{100%ml}.\n",
     )
     .unwrap();
+
+    let config_dir = dir.path().join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("pantry.conf"),
+        "[pantry]\nflour = \"1%kg\"\n",
+    )
+    .unwrap();
+}
+
+/// Points a spawned `cook server` at a `HOME`/`XDG_CONFIG_HOME` inside the
+/// test's own `TempDir`, so a global `~/.config/cook/pantry.conf` (or the
+/// macOS equivalent) on the machine running the test cannot change which
+/// config file `Context::discover` finds and, in turn, what these tests
+/// observe.
+fn with_isolated_home<'a>(cmd: &'a mut Command, dir: &TempDir) -> &'a mut Command {
+    let home = dir.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    cmd.env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
 }
 
 /// `free_port` only reserves a port long enough to learn its number, so with
@@ -94,7 +117,7 @@ async fn try_start_server(extra_args: &[&str]) -> Option<ServerGuard> {
     for arg in extra_args {
         cmd.arg(arg);
     }
-    let child = cmd
+    let child = with_isolated_home(&mut cmd, &dir)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -141,7 +164,9 @@ fn run_server_startup(extra_args: &[&str]) -> Output {
     for arg in extra_args {
         cmd.arg(arg);
     }
-    cmd.output().expect("run cook server")
+    with_isolated_home(&mut cmd, &dir)
+        .output()
+        .expect("run cook server")
 }
 
 /// Sends an `OPTIONS` preflight for `POST /api/pantry/add` from `origin`,
@@ -340,11 +365,11 @@ async fn default_policy_same_origin_post_is_not_blocked() {
     let resp = post_pantry_add(&server, Some(&own_origin)).await;
 
     let status = resp.status();
-    assert_ne!(
+    assert_eq!(
         status,
-        StatusCode::FORBIDDEN,
+        StatusCode::OK,
         "a POST whose Origin matches the server's own Host (the web UI's own request) \
-         must not be blocked by the write guard, got {status}"
+         must not be blocked by the write guard and must actually succeed, got {status}"
     );
 }
 
@@ -380,10 +405,10 @@ async fn explicit_origin_write_guard_matches_the_configured_list() {
     let server = start_server(&["--cors-origin", "http://app.test"]).await;
 
     let allowed = post_pantry_add(&server, Some("http://app.test")).await;
-    assert_ne!(
+    assert_eq!(
         allowed.status(),
-        StatusCode::FORBIDDEN,
-        "a POST from a listed --cors-origin must not be blocked, got {}",
+        StatusCode::OK,
+        "a POST from a listed --cors-origin must not be blocked and must actually succeed, got {}",
         allowed.status()
     );
 

--- a/tests/cors_test.rs
+++ b/tests/cors_test.rs
@@ -1,0 +1,415 @@
+//! End-to-end tests for `cook server`'s CORS policy: the `tower_http`
+//! `CorsLayer` built from `--cors-origin` / `--cors-allow-credentials`, and the
+//! server-side write guard in `src/server/cors.rs` that sits inside it.
+//!
+//! Two mechanisms, two testing strategies:
+//!
+//! - The CORS **response headers** are browser-enforced, so a real `OPTIONS`
+//!   preflight (with `Origin` and `Access-Control-Request-Method`) is the right
+//!   way to observe them.
+//! - The **write guard** exists precisely because headers cannot express its
+//!   rule: `POST` is a CORS-safelisted method, so a browser never consults
+//!   `Access-Control-Allow-Methods` before sending one — `allow_methods([GET])`
+//!   does nothing to stop a cross-origin `POST`. Under the wildcard-origin
+//!   default, `AllowOrigin::any()` also answers every preflight, including a
+//!   `POST` preflight, with `Access-Control-Allow-Origin: *`. So a test that
+//!   sends a `POST` preflight and asserts that header is absent would fail
+//!   against *correct* code — it proves nothing about whether the write itself
+//!   is refused. The only way to observe the guard is to send a real
+//!   cross-origin `POST` and check the status code it comes back with. Do not
+//!   "simplify" the write-guard tests below into preflight assertions.
+
+#![cfg(feature = "server")]
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ORIGIN};
+use reqwest::{Client, Method, Response, StatusCode};
+use std::net::TcpListener;
+use std::process::{Child, Command, Output, Stdio};
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// Kills the spawned server when the test ends, pass or panic.
+struct ServerGuard {
+    child: Child,
+    port: u16,
+    #[allow(dead_code)] // keeps the fixture directory alive for the server's lifetime
+    dir: TempDir,
+}
+
+impl ServerGuard {
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, path)
+    }
+
+    /// The `Origin` a same-origin request from this server's own web UI would
+    /// carry.
+    fn own_origin(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+/// One minimal recipe, just enough for the server to have something to scan.
+fn write_fixture(dir: &TempDir) {
+    std::fs::write(
+        dir.path().join("Recipe.cook"),
+        "Mix @flour{100%g} and @water{100%ml}.\n",
+    )
+    .unwrap();
+}
+
+/// `free_port` only reserves a port long enough to learn its number, so with
+/// several tests booting servers at once another one can claim it first. The
+/// server exits 1 on a bound port, so retry with a fresh one.
+async fn start_server(extra_args: &[&str]) -> ServerGuard {
+    for _ in 0..5 {
+        if let Some(server) = try_start_server(extra_args).await {
+            return server;
+        }
+    }
+    panic!("could not start cook server on a free port after 5 attempts");
+}
+
+async fn try_start_server(extra_args: &[&str]) -> Option<ServerGuard> {
+    let dir = TempDir::new().expect("temp dir");
+    write_fixture(&dir);
+
+    let port = free_port();
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("cook"));
+    cmd.arg("server")
+        .arg(dir.path())
+        .arg("--port")
+        .arg(port.to_string());
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+    let child = cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cook server");
+
+    let mut guard = ServerGuard { child, port, dir };
+
+    // Plain GET with no Origin header: unaffected by any --cors-* flag, so
+    // this is a valid readiness probe regardless of which policy a test asks
+    // for.
+    let client = Client::new();
+    let url = guard.url("/api/menus");
+    for _ in 0..200 {
+        if guard.child.try_wait().expect("poll server").is_some() {
+            // Port was taken between reserving and binding it.
+            return None;
+        }
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                return Some(guard);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("cook server on port {port} never became ready");
+}
+
+/// Runs `cook server` against a fresh temp fixture and returns once the
+/// process exits, without waiting for readiness. Used for the startup
+/// validation tests, where the process is expected to fail before it ever
+/// binds a listener.
+fn run_server_startup(extra_args: &[&str]) -> Output {
+    let dir = TempDir::new().expect("temp dir");
+    write_fixture(&dir);
+
+    // Reserved so a wrongly-successful startup can't collide with another
+    // test's server rather than failing visibly.
+    let port = free_port();
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("cook"));
+    cmd.arg("server")
+        .arg(dir.path())
+        .arg("--port")
+        .arg(port.to_string());
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("run cook server")
+}
+
+/// Sends an `OPTIONS` preflight for `POST /api/pantry/add` from `origin`,
+/// declaring an intent to send `request_method`, and returns the response
+/// headers for the caller to assert on.
+async fn preflight(server: &ServerGuard, origin: &str, request_method: &str) -> HeaderMap {
+    Client::new()
+        .request(Method::OPTIONS, server.url("/api/pantry/add"))
+        .header(ORIGIN, origin)
+        .header("access-control-request-method", request_method)
+        .send()
+        .await
+        .expect("preflight request")
+        .headers()
+        .clone()
+}
+
+/// Reads a header as UTF-8 text, for readable assertion failures.
+fn header(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(HeaderName::from_bytes(name.as_bytes()).expect("valid header name"))
+        .map(|v: &HeaderValue| v.to_str().unwrap_or("<non-utf8>").to_string())
+}
+
+/// Sends a real (non-preflight) `POST /api/pantry/add`, optionally with an
+/// `Origin` header, and returns the response. This is what actually exercises
+/// the write guard — see the module doc comment for why a preflight cannot.
+async fn post_pantry_add(server: &ServerGuard, origin: Option<&str>) -> Response {
+    let mut req = Client::new()
+        .post(server.url("/api/pantry/add"))
+        .json(&serde_json::json!({ "section": "Test", "name": "Test Item" }));
+    if let Some(origin) = origin {
+        req = req.header(ORIGIN, origin);
+    }
+    req.send().await.expect("pantry add request")
+}
+
+async fn get_with_origin(server: &ServerGuard, path: &str, origin: &str) -> Response {
+    Client::new()
+        .get(server.url(path))
+        .header(ORIGIN, origin)
+        .send()
+        .await
+        .expect("GET request")
+}
+
+// ---------------------------------------------------------------------------
+// Preflight / header tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn default_policy_preflight_get_is_wide_open() {
+    let server = start_server(&[]).await;
+    let headers = preflight(&server, "http://evil.test", "GET").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin").as_deref(),
+        Some("*"),
+        "default policy must allow any origin for GET, got headers: {headers:?}"
+    );
+    let methods = header(&headers, "access-control-allow-methods");
+    assert!(
+        methods.as_deref().is_some_and(|m| m.contains("GET")),
+        "GET must be an allowed method, got access-control-allow-methods: {methods:?}"
+    );
+}
+
+#[tokio::test]
+async fn default_policy_preflight_put_is_not_in_allowed_methods() {
+    let server = start_server(&[]).await;
+    let headers = preflight(&server, "http://evil.test", "PUT").await;
+
+    // Deliberately not asserting anything about access-control-allow-origin
+    // here: AllowOrigin::any() answers "*" on every preflight regardless of
+    // the requested method, so its presence says nothing about PUT being
+    // allowed.
+    assert_eq!(
+        header(&headers, "access-control-allow-methods").as_deref(),
+        Some("GET"),
+        "wildcard-origin policy must only ever advertise GET, got headers: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_origin_preflight_post_from_listed_origin_is_allowed() {
+    let server = start_server(&["--cors-origin", "http://app.test"]).await;
+    let headers = preflight(&server, "http://app.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin").as_deref(),
+        Some("http://app.test"),
+        "listed origin must be echoed back, got headers: {headers:?}"
+    );
+    let methods = header(&headers, "access-control-allow-methods");
+    assert!(
+        methods.as_deref().is_some_and(|m| m.contains("POST")),
+        "POST must be allowed once an explicit origin is named, got access-control-allow-methods: {methods:?}"
+    );
+    let allow_headers = header(&headers, "access-control-allow-headers");
+    assert!(
+        allow_headers
+            .as_deref()
+            .is_some_and(|h| h.to_lowercase().contains("content-type")),
+        "content-type must be an allowed request header, got access-control-allow-headers: {allow_headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn explicit_origin_preflight_post_from_unlisted_origin_is_refused() {
+    let server = start_server(&["--cors-origin", "http://app.test"]).await;
+    let headers = preflight(&server, "http://evil.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-origin"),
+        None,
+        "an origin outside the explicit list must get no access-control-allow-origin, got headers: {headers:?}"
+    );
+}
+
+#[tokio::test]
+async fn cors_allow_credentials_is_advertised_for_listed_origins() {
+    let server = start_server(&[
+        "--cors-origin",
+        "http://app.test",
+        "--cors-allow-credentials",
+    ])
+    .await;
+    let headers = preflight(&server, "http://app.test", "POST").await;
+
+    assert_eq!(
+        header(&headers, "access-control-allow-credentials").as_deref(),
+        Some("true"),
+        "credentials must be advertised once opted in, got headers: {headers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Write-guard tests (real requests, not preflights — see module doc comment)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn default_policy_cross_origin_post_is_refused_with_403() {
+    let server = start_server(&[]).await;
+    let resp = post_pantry_add(&server, Some("http://evil.test")).await;
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "cross-origin POST under the wildcard default must be refused, got {status}: {body}"
+    );
+    assert!(
+        body.contains("--cors-origin"),
+        "refusal body must tell the operator how to fix it, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn default_policy_same_origin_post_is_not_blocked() {
+    let server = start_server(&[]).await;
+    let own_origin = server.own_origin();
+    let resp = post_pantry_add(&server, Some(&own_origin)).await;
+
+    let status = resp.status();
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a POST whose Origin matches the server's own Host (the web UI's own request) \
+         must not be blocked by the write guard, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn default_policy_post_without_origin_is_not_blocked() {
+    let server = start_server(&[]).await;
+    let resp = post_pantry_add(&server, None).await;
+
+    let status = resp.status();
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a POST with no Origin header (curl, scripts, other non-browser clients) \
+         must not be blocked by the write guard, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn default_policy_cross_origin_get_is_allowed() {
+    let server = start_server(&[]).await;
+    let resp = get_with_origin(&server, "/api/menus", "http://evil.test").await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "reads must stay open to any origin under the default policy, got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn explicit_origin_write_guard_matches_the_configured_list() {
+    let server = start_server(&["--cors-origin", "http://app.test"]).await;
+
+    let allowed = post_pantry_add(&server, Some("http://app.test")).await;
+    assert_ne!(
+        allowed.status(),
+        StatusCode::FORBIDDEN,
+        "a POST from a listed --cors-origin must not be blocked, got {}",
+        allowed.status()
+    );
+
+    let refused = post_pantry_add(&server, Some("http://evil.test")).await;
+    assert_eq!(
+        refused.status(),
+        StatusCode::FORBIDDEN,
+        "a POST from an origin outside the --cors-origin list must be refused, got {}",
+        refused.status()
+    );
+}
+
+#[tokio::test]
+async fn no_csrf_check_disables_the_write_guard() {
+    let server = start_server(&["--no-csrf-check"]).await;
+    let resp = post_pantry_add(&server, Some("http://evil.test")).await;
+
+    let status = resp.status();
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "--no-csrf-check must disable the write guard entirely, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Startup validation tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn credentials_without_explicit_origin_fails_to_start() {
+    let output = run_server_startup(&["--cors-allow-credentials"]);
+
+    assert!(
+        !output.status.success(),
+        "server must refuse to start with --cors-allow-credentials and no --cors-origin, \
+         exit status: {}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--cors-origin"),
+        "startup error must point at --cors-origin as the fix, got stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_mixed_with_explicit_origin_fails_to_start() {
+    let output = run_server_startup(&["--cors-origin", "*", "--cors-origin", "http://app.test"]);
+
+    assert!(
+        !output.status.success(),
+        "server must refuse to start when --cors-origin '*' is combined with an explicit origin, \
+         exit status: {}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be combined"),
+        "startup error must explain the conflict, got stderr: {stderr}"
+    );
+}

--- a/tests/cors_test.rs
+++ b/tests/cors_test.rs
@@ -130,7 +130,10 @@ async fn try_start_server(extra_args: &[&str]) -> Option<ServerGuard> {
     // for.
     let client = Client::new();
     let url = guard.url("/api/menus");
-    for _ in 0..200 {
+    // 30s. Every test here boots its own server, so a full parallel run spawns
+    // more of them at once than the suites this pattern came from — a loaded
+    // machine can take well past the 10s that was enough for nine.
+    for _ in 0..600 {
         if guard.child.try_wait().expect("poll server").is_some() {
             // Port was taken between reserving and binding it.
             return None;

--- a/tests/cors_test.rs
+++ b/tests/cors_test.rs
@@ -301,6 +301,39 @@ async fn default_policy_cross_origin_post_is_refused_with_403() {
 }
 
 #[tokio::test]
+async fn a_forwarded_host_header_cannot_fake_same_origin() {
+    // The guard reads the real `Host` header, never `Forwarded` /
+    // `X-Forwarded-Host`. Those are set by whoever is on the other end of a
+    // direct connection, so trusting them would let `Origin: http://evil.test`
+    // plus `X-Forwarded-Host: evil.test` pass as same-origin.
+    let server = start_server(&[]).await;
+
+    for spoof in [
+        ("x-forwarded-host", "evil.test"),
+        ("forwarded", "host=evil.test"),
+    ] {
+        let resp = Client::new()
+            .post(server.url("/api/pantry/add"))
+            .json(&serde_json::json!({ "section": "Test", "name": "Test Item" }))
+            .header(ORIGIN, "http://evil.test")
+            .header(spoof.0, spoof.1)
+            .send()
+            .await
+            .expect("pantry add request");
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{}: {} must not make a cross-origin write look same-origin, got {status}: {body}",
+            spoof.0,
+            spoof.1
+        );
+    }
+}
+
+#[tokio::test]
 async fn default_policy_same_origin_post_is_not_blocked() {
     let server = start_server(&[]).await;
     let own_origin = server.own_origin();


### PR DESCRIPTION
Closes #465.

`cook server` applied one hardcoded CORS policy that was wrong in both directions: too permissive (any page could reach the mutating routes of a `--host`-exposed server) and too restrictive (`allow_headers` was never set, so a cross-origin JSON `POST` failed preflight and legitimate integrations had to patch the binary).

## What changed

- `--cors-origin <ORIGIN>` — repeatable; `*` for any origin, the default.
- `--cors-allow-credentials` — requires explicit origins; errors against a wildcard.
- `content-type` is now always an allowed request header, so cross-origin JSON works.
- Under a wildcard origin, cross-origin **writes are refused with `403`**. Naming origins with `--cors-origin` lets those origins write.
- `--no-cors` is renamed `--no-csrf-check` — it gates the same-origin check and never touched the CORS layer. The old spelling still works as a hidden alias.

## The part worth reviewing

The obvious implementation — `allow_methods([GET])` for a wildcard origin — **does not work**, and shipping it would have made the default *more* permissive than the code it replaced.

`POST` is a CORS-safelisted method, so per the Fetch standard a browser only consults `Access-Control-Allow-Methods` for methods that are *not* safelisted. `Access-Control-Allow-Methods: GET` blocks `PUT` and `DELETE` but never `POST`. Demonstrated in a real browser: a cross-origin page wrote to `seed/config/pantry.conf` via `POST /api/pantry/add`. And the only thing blocking cross-origin JSON `POST` before this PR was the *unset* `allow_headers` failing the preflight by accident — which the issue correctly asks us to remove.

So read-only is enforced **server-side**, by a small write guard, and the CORS headers describe the policy rather than enforce it. The guard, in order:

1. `GET`/`HEAD`/`OPTIONS` pass.
2. No `Origin` header → pass. `curl`, scripts and every non-browser client send none, and the API has no authentication for them to bypass.
3. `Origin` matching the request's `Host` → pass (same-origin; the web UI's own writes).
4. `Origin` in the `--cors-origin` list → pass.
5. Otherwise `403`.

It reads the real `Host` header only, never `Forwarded` / `X-Forwarded-Host` — an earlier revision used axum-extra's `Host` extractor, and `Origin: http://evil.test` plus `X-Forwarded-Host: evil.test` passed as same-origin (`abe2976`).

## Compatibility

**Cross-origin browser writes now need `--cors-origin`.** Same-origin traffic is unaffected, and so is anything that isn't a browser — `curl` and existing scripts send no `Origin` and pass by rule 2.

**Behind a reverse proxy that rewrites `Host`**, pass the public origin: `--cors-origin https://cook.example.com`. A proxy that passes `Host` through unchanged needs no configuration.

## A deliberate non-fix

`origin_matches_host` ignores the scheme, so `Origin: https://a.test` matches `Host: a.test`. That is the normal TLS-terminating-proxy case, and rejecting it would break those deployments. The converse reading — an `https://` page reaching a plaintext server on port 80 — is blocked by browsers' mixed-content policy. Documented and pinned by a test rather than left implicit.

## Testing

24 unit tests in `src/server/cors.rs` (flag validation, origin parsing, guard rules) and 14 end-to-end tests in `tests/cors_test.rs` that boot a real server. The cross-origin `POST` case is tested with a real request, not a preflight: `AllowOrigin::any()` answers `*` on every preflight, so the headers alone cannot show whether the write was refused.

Design: `docs/superpowers/specs/2026-09-03-server-cors-config-design.md`

## Follow-up

Re-run cooklang.org's `scripts/sync-cli-docs.sh` after merge to pick up `docs/api.md` and `docs/server.md`.

https://claude.ai/code/session_013cPWotrjEY4Jac87e6vHsh