### PR TITLE
fix(web): close the UI follow-ups from #456

### DIFF
--- a/locales/de-DE/common.ftl
+++ b/locales/de-DE/common.ftl
@@ -52,3 +52,13 @@ new-recipe-create = Rezept erstellen
 delete-recipe = Rezept löschen
 delete-recipe-confirm = Möchten Sie dieses Rezept wirklich löschen?
 delete-recipe-warning = Diese Aktion kann nicht rückgängig gemacht werden.
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Design umschalten
+aria-keyboard-shortcuts = Tastenkürzel
+aria-more-options = Weitere Optionen
+aria-preferences = Einstellungen
+aria-dismiss = Schließen
+aria-decrease-scale = Skalierung verringern
+aria-increase-scale = Skalierung erhöhen
+aria-close = Schließen

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -56,3 +56,13 @@ delete-recipe-warning = This action cannot be undone.
 # Errors
 error-title = Something went wrong
 error-back-home = Back to recipes
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Toggle theme
+aria-keyboard-shortcuts = Keyboard shortcuts
+aria-more-options = More options
+aria-preferences = Preferences
+aria-dismiss = Dismiss
+aria-decrease-scale = Decrease scale
+aria-increase-scale = Increase scale
+aria-close = Close

--- a/locales/es-ES/common.ftl
+++ b/locales/es-ES/common.ftl
@@ -52,3 +52,13 @@ new-recipe-create = Crear Receta
 delete-recipe = Eliminar Receta
 delete-recipe-confirm = ¿Estás seguro de que quieres eliminar esta receta?
 delete-recipe-warning = Esta acción no se puede deshacer.
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Cambiar tema
+aria-keyboard-shortcuts = Atajos de teclado
+aria-more-options = Más opciones
+aria-preferences = Preferencias
+aria-dismiss = Cerrar
+aria-decrease-scale = Reducir escala
+aria-increase-scale = Aumentar escala
+aria-close = Cerrar

--- a/locales/eu-ES/common.ftl
+++ b/locales/eu-ES/common.ftl
@@ -52,3 +52,13 @@ new-recipe-create = Sortu errezeta
 delete-recipe = Ezabatu errezeta
 delete-recipe-confirm = Ziur zaude errezeta hau ezabatu nahi duzula?
 delete-recipe-warning = Ekintza hau ezin da desegin.
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Gaia aldatu
+aria-keyboard-shortcuts = Teklatu-lasterbideak
+aria-more-options = Aukera gehiago
+aria-preferences = Hobespenak
+aria-dismiss = Itxi
+aria-decrease-scale = Eskala txikitu
+aria-increase-scale = Eskala handitu
+aria-close = Itxi

--- a/locales/fr-FR/common.ftl
+++ b/locales/fr-FR/common.ftl
@@ -52,3 +52,13 @@ new-recipe-create = Creer la Recette
 delete-recipe = Supprimer la Recette
 delete-recipe-confirm = Êtes-vous sûr de vouloir supprimer cette recette?
 delete-recipe-warning = Cette action est irréversible.
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Changer de thème
+aria-keyboard-shortcuts = Raccourcis clavier
+aria-more-options = Plus d'options
+aria-preferences = Préférences
+aria-dismiss = Fermer
+aria-decrease-scale = Réduire l'échelle
+aria-increase-scale = Augmenter l'échelle
+aria-close = Fermer

--- a/locales/nl-NL/common.ftl
+++ b/locales/nl-NL/common.ftl
@@ -52,3 +52,13 @@ new-recipe-create = Recept Aanmaken
 delete-recipe = Recept Verwijderen
 delete-recipe-confirm = Weet je zeker dat je dit recept wilt verwijderen?
 delete-recipe-warning = Deze actie kan niet ongedaan worden gemaakt.
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Thema wisselen
+aria-keyboard-shortcuts = Sneltoetsen
+aria-more-options = Meer opties
+aria-preferences = Voorkeuren
+aria-dismiss = Sluiten
+aria-decrease-scale = Schaal verkleinen
+aria-increase-scale = Schaal vergroten
+aria-close = Sluiten

--- a/locales/sv-SE/common.ftl
+++ b/locales/sv-SE/common.ftl
@@ -56,3 +56,13 @@ delete-recipe-warning = Detta kan inte ångras.
 # Errors
 error-title = Något gick snett
 error-back-home = Tillbaka till recept
+
+# Icon button labels (aria-label / title)
+aria-toggle-theme = Byt tema
+aria-keyboard-shortcuts = Tangentbordsgenvägar
+aria-more-options = Fler alternativ
+aria-preferences = Inställningar
+aria-dismiss = Stäng
+aria-decrease-scale = Minska skala
+aria-increase-scale = Öka skala
+aria-close = Stäng

--- a/src/build/writer.rs
+++ b/src/build/writer.rs
@@ -24,10 +24,27 @@ pub fn write_bytes(output_root: &Utf8Path, relpath: &Utf8Path, bytes: &[u8]) -> 
     Ok(())
 }
 
-/// Copy every file in the rust-embed `StaticFiles` to `output_root/static/<path>`.
+/// Embedded `static/` paths that are build inputs rather than shipped assets.
+/// Pages only link the compiled `output.css` and `editor.bundle.js`, so the
+/// Tailwind sources and the unbundled editor modules stay out of the site.
+const EXCLUDED_STATIC_PREFIXES: &[&str] = &["css/input.css", "css/components.css", "js/src/"];
+
+/// Whether an embedded `static/` path (relative to `static/`) belongs in the
+/// generated site.
+fn is_shipped_asset(path: &str) -> bool {
+    !EXCLUDED_STATIC_PREFIXES
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}
+
+/// Copy every shipped file in the rust-embed `StaticFiles` to
+/// `output_root/static/<path>`, skipping stylesheet and script sources.
 pub fn copy_static_assets(output_root: &Utf8Path) -> Result<usize> {
     let mut count = 0;
     for path in crate::web::StaticFiles::iter() {
+        if !is_shipped_asset(path.as_ref()) {
+            continue;
+        }
         let rel = Utf8Path::new("static").join(path.as_ref());
         let file = crate::web::StaticFiles::get(path.as_ref())
             .with_context(|| format!("Embedded file vanished: {path}"))?;
@@ -147,5 +164,28 @@ mod tests {
         let count = copy_static_assets(root).unwrap();
         assert!(count > 0, "should copy at least one static asset");
         assert!(root.join("static/css/output.css").is_file());
+        assert!(root.join("static/js/editor.bundle.js").is_file());
+    }
+
+    #[test]
+    fn copy_static_assets_skips_build_inputs() {
+        let tmp = TempDir::new().unwrap();
+        let root = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        copy_static_assets(root).unwrap();
+        assert!(!root.join("static/css/input.css").exists());
+        assert!(!root.join("static/css/components.css").exists());
+        assert!(!root.join("static/js/src").exists());
+    }
+
+    #[test]
+    fn is_shipped_asset_excludes_sources_only() {
+        assert!(is_shipped_asset("css/output.css"));
+        assert!(is_shipped_asset("css/cooking-mode.css"));
+        assert!(is_shipped_asset("js/editor.bundle.js"));
+        assert!(is_shipped_asset("favicon.ico"));
+        assert!(!is_shipped_asset("css/input.css"));
+        assert!(!is_shipped_asset("css/components.css"));
+        assert!(!is_shipped_asset("js/src/editor.js"));
+        assert!(!is_shipped_asset("js/src/cooklang-mode.js"));
     }
 }

--- a/src/web/builders.rs
+++ b/src/web/builders.rs
@@ -200,8 +200,12 @@ enum NaturalChunk {
 
 /// Split a name into digit runs and non-digit runs, lowercased, so that
 /// "Recipe 9" sorts before "Recipe 10" and case does not split otherwise
-/// equal names. Mirrors the client-side `Intl.Collator` with
-/// `{ numeric: true, sensitivity: 'base' }` used by `templates/recipes.html`.
+/// equal names. This folds case and digits like the client-side
+/// `Intl.Collator` with `{ numeric: true, sensitivity: 'base' }` in
+/// `templates/recipes.html`, but not accents: non-ASCII letters keep code
+/// point order, so "Äpfel" sorts after "zucchini". The client therefore
+/// leaves the served order alone on the default sort and only re-sorts
+/// when the user picks another field or direction.
 fn natural_key(name: &str) -> Vec<NaturalChunk> {
     let mut chunks = Vec::new();
     let mut text = String::new();
@@ -1152,8 +1156,17 @@ fn get_image_path(base_path: &Utf8Path, prefix: &str, img_path: String) -> Optio
 
 #[cfg(test)]
 mod natural_sort_tests {
-    use super::natural_cmp;
+    use super::{natural_cmp, natural_key};
     use std::cmp::Ordering;
+
+    #[test]
+    fn non_ascii_letters_keep_code_point_order() {
+        // Accents are not folded: this pins the documented divergence from
+        // the browser collator so a change here is deliberate.
+        assert_eq!(natural_cmp("zucchini", "Äpfel"), Ordering::Less);
+        // Case still folds for non-ASCII letters.
+        assert_eq!(natural_key("äpfel"), natural_key("Äpfel"));
+    }
 
     #[test]
     fn case_insensitive() {

--- a/src/web/builders.rs
+++ b/src/web/builders.rs
@@ -138,7 +138,7 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
     items.sort_by(|a, b| match (a.is_directory, b.is_directory) {
         (true, false) => std::cmp::Ordering::Less,
         (false, true) => std::cmp::Ordering::Greater,
-        _ => a.name.cmp(&b.name),
+        _ => natural_cmp(&a.name, &b.name),
     });
 
     let todays_menu = if sub_path.is_none() {
@@ -188,6 +188,57 @@ pub fn build_recipes_template(input: RecipesBuildInput<'_>) -> Result<RecipesTem
         repo_url,
         features,
     })
+}
+
+/// One chunk of a name for natural sorting: a run of digits compared by
+/// value, or a run of anything else compared as lowercase text.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum NaturalChunk {
+    Number(u128),
+    Text(String),
+}
+
+/// Split a name into digit runs and non-digit runs, lowercased, so that
+/// "Recipe 9" sorts before "Recipe 10" and case does not split otherwise
+/// equal names. Mirrors the client-side `Intl.Collator` with
+/// `{ numeric: true, sensitivity: 'base' }` used by `templates/recipes.html`.
+fn natural_key(name: &str) -> Vec<NaturalChunk> {
+    let mut chunks = Vec::new();
+    let mut text = String::new();
+    let mut digits = String::new();
+
+    let flush_text = |text: &mut String, chunks: &mut Vec<NaturalChunk>| {
+        if !text.is_empty() {
+            chunks.push(NaturalChunk::Text(std::mem::take(text)));
+        }
+    };
+    let flush_digits = |digits: &mut String, chunks: &mut Vec<NaturalChunk>| {
+        if !digits.is_empty() {
+            // Cap absurdly long digit runs instead of panicking on overflow.
+            let value = digits.parse::<u128>().unwrap_or(u128::MAX);
+            digits.clear();
+            chunks.push(NaturalChunk::Number(value));
+        }
+    };
+
+    for c in name.chars() {
+        if c.is_ascii_digit() {
+            flush_text(&mut text, &mut chunks);
+            digits.push(c);
+        } else {
+            flush_digits(&mut digits, &mut chunks);
+            text.extend(c.to_lowercase());
+        }
+    }
+    flush_text(&mut text, &mut chunks);
+    flush_digits(&mut digits, &mut chunks);
+    chunks
+}
+
+/// Case-insensitive natural ordering. Ties (names that differ only in case
+/// or leading zeros) fall back to byte order so the sort stays deterministic.
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    natural_key(a).cmp(&natural_key(b)).then_with(|| a.cmp(b))
 }
 
 /// Inputs for [`build_recipe_template`].
@@ -1096,5 +1147,88 @@ fn get_image_path(base_path: &Utf8Path, prefix: &str, img_path: String) -> Optio
                 .file_name()
                 .map(|name| format!("{prefix}/api/static/{name}"))
         }
+    }
+}
+
+#[cfg(test)]
+mod natural_sort_tests {
+    use super::natural_cmp;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(natural_cmp("apple pie", "Banana bread"), Ordering::Less);
+        assert_eq!(natural_cmp("Banana bread", "apple pie"), Ordering::Greater);
+    }
+
+    #[test]
+    fn digit_runs_compare_numerically() {
+        assert_eq!(natural_cmp("Recipe 9", "Recipe 10"), Ordering::Less);
+        assert_eq!(natural_cmp("Recipe 10", "Recipe 9"), Ordering::Greater);
+        assert_eq!(natural_cmp("Recipe 10", "Recipe 10"), Ordering::Equal);
+    }
+
+    #[test]
+    fn case_only_differences_are_stable_ties() {
+        // Equal under the natural key; byte order breaks the tie so the
+        // result is deterministic across runs.
+        assert_eq!(natural_cmp("a", "A"), Ordering::Greater);
+        assert_eq!(natural_cmp("A", "a"), Ordering::Less);
+        assert_eq!(natural_cmp("a", "a"), Ordering::Equal);
+    }
+
+    #[test]
+    fn sorts_like_the_client_collator() {
+        let mut names = vec![
+            "Recipe 10",
+            "banana bread",
+            "Recipe 9",
+            "Apple pie",
+            "recipe 2",
+        ];
+        names.sort_by(|a, b| natural_cmp(a, b));
+        assert_eq!(
+            names,
+            vec![
+                "Apple pie",
+                "banana bread",
+                "recipe 2",
+                "Recipe 9",
+                "Recipe 10"
+            ]
+        );
+    }
+
+    #[test]
+    fn directories_come_before_recipes() {
+        struct Item {
+            name: &'static str,
+            is_directory: bool,
+        }
+        let mut items = [
+            Item {
+                name: "zucchini",
+                is_directory: false,
+            },
+            Item {
+                name: "Soups",
+                is_directory: true,
+            },
+            Item {
+                name: "Apple pie",
+                is_directory: false,
+            },
+            Item {
+                name: "breakfast",
+                is_directory: true,
+            },
+        ];
+        items.sort_by(|a, b| match (a.is_directory, b.is_directory) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => natural_cmp(a.name, b.name),
+        });
+        let order: Vec<_> = items.iter().map(|i| i.name).collect();
+        assert_eq!(order, vec!["breakfast", "Soups", "Apple pie", "zucchini"]);
     }
 }

--- a/static/css/input.css
+++ b/static/css/input.css
@@ -273,3 +273,42 @@ body {
 .cm-editor ::selection {
     background: color-mix(in srgb, var(--info) 30%, transparent) !important;
 }
+
+/* Cooklang syntax highlighting. editor.js assigns one fixed class per token
+   kind (HighlightStyle `class`), so every colour resolves through the theme
+   tokens and flips with light/dark like the rest of the editor chrome. */
+.cm-editor .cm-cook-ingredient {
+    color: var(--accent-text);
+    font-weight: 600;
+}
+
+.cm-editor .cm-cook-cookware {
+    color: var(--ok);
+    font-weight: 600;
+}
+
+.cm-editor .cm-cook-timer {
+    color: var(--danger);
+    font-weight: 600;
+}
+
+.cm-editor .cm-cook-unit,
+.cm-editor .cm-cook-metadata {
+    color: var(--text-muted);
+}
+
+.cm-editor .cm-cook-comment {
+    color: var(--text-faint);
+    font-style: italic;
+}
+
+.cm-editor .cm-cook-section {
+    color: var(--text);
+    font-weight: 700;
+    font-size: 1.1em;
+}
+
+.cm-editor .cm-cook-prep {
+    color: var(--info);
+    font-style: italic;
+}

--- a/static/js/keyboard-shortcuts.js
+++ b/static/js/keyboard-shortcuts.js
@@ -118,6 +118,10 @@
                 </div>
             </div>`;
 
+        // Translated strings are injected by base.html; fall back to English.
+        const strings = window.__STRINGS__ || {};
+        const closeLabel = String(strings.close || 'Close')
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
         const modal = document.createElement('div');
         modal.id = 'keyboard-shortcuts-modal';
         modal.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
@@ -125,7 +129,7 @@
             <div class="card shadow-[var(--shadow-overlay)] max-w-2xl w-full mx-4 max-h-[80vh] overflow-hidden">
                 <div class="p-6 border-b border-line flex justify-between items-center">
                     <h2 class="text-title font-bold text-text">Keyboard Shortcuts</h2>
-                    <button onclick="closeShortcutsHelp()" class="icon-btn" aria-label="Close">
+                    <button onclick="closeShortcutsHelp()" class="icon-btn" aria-label="${closeLabel}">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>

--- a/static/js/src/editor.js
+++ b/static/js/src/editor.js
@@ -89,16 +89,18 @@ async function cooklangCompletions(context) {
     }
 }
 
-// Custom highlight style for Cooklang syntax
+// Custom highlight style for Cooklang syntax. Each token kind gets a fixed
+// class; colour and weight live in static/css/input.css (`.cm-cook-*`) so
+// they resolve through the theme tokens and flip with light/dark.
 const cooklangHighlightStyle = HighlightStyle.define([
-  { tag: t.variableName, color: "#ea580c", fontWeight: "600" },  // Ingredients (orange)
-  { tag: t.keyword, color: "#16a34a", fontWeight: "600" },       // Cookware (green)
-  { tag: t.number, color: "#dc2626", fontWeight: "600" },        // Timers (red)
-  { tag: t.comment, color: "#9ca3af", fontStyle: "italic" },     // Comments
-  { tag: t.meta, color: "#8b5cf6" },                             // Metadata
-  { tag: t.unit, color: "#6366f1" },                             // Units
-  { tag: t.heading, color: "#0891b2", fontWeight: "700", fontSize: "1.1em" },  // Sections (cyan)
-  { tag: t.string, color: "#d97706", fontStyle: "italic" }       // Prep instructions (amber italic)
+  { tag: t.variableName, class: "cm-cook-ingredient" },
+  { tag: t.keyword, class: "cm-cook-cookware" },
+  { tag: t.number, class: "cm-cook-timer" },
+  { tag: t.comment, class: "cm-cook-comment" },
+  { tag: t.meta, class: "cm-cook-metadata" },
+  { tag: t.unit, class: "cm-cook-unit" },
+  { tag: t.heading, class: "cm-cook-section" },
+  { tag: t.string, class: "cm-cook-prep" }
 ]);
 
 // Editor base theme for layout

--- a/templates/api_docs.html
+++ b/templates/api_docs.html
@@ -71,7 +71,7 @@
                     {% endif %}
                 </div>
 
-                <p class="text-sm font-medium mb-1">{{ endpoint.summary|inline_code|safe }}</p>
+                <h3 class="text-sm font-medium mb-1">{{ endpoint.summary|inline_code|safe }}</h3>
                 {% if !endpoint.description.is_empty() %}
                 <p class="text-sm text-muted">{{ endpoint.description|inline_code|safe }}</p>
                 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -285,16 +285,16 @@
                         {% endif %}
                         <!-- Inline buttons on md+ screens -->
                         {% if !static_mode %}
-                        <a href="{{ prefix }}/preferences" class="icon-btn hidden md:inline-flex {% if active == "preferences" %}bg-accent-soft text-accent-text{% endif %}" aria-label="Preferences" title="Preferences">
+                        <a href="{{ prefix }}/preferences" class="icon-btn hidden md:inline-flex {% if active == "preferences" %}bg-accent-soft text-accent-text{% endif %}" aria-label="{{ tr.t("aria-preferences") }}" title="{{ tr.t("aria-preferences") }}">
                             <span>⚙️</span>
                         </a>
                         {% endif %}
-                        <button onclick="showShortcutsHelp()" class="icon-btn hidden md:inline-flex ml-2 print:hidden" aria-label="Keyboard shortcuts" title="Keyboard shortcuts (?)">
+                        <button onclick="showShortcutsHelp()" class="icon-btn hidden md:inline-flex ml-2 print:hidden" aria-label="{{ tr.t("aria-keyboard-shortcuts") }}" title="{{ tr.t("aria-keyboard-shortcuts") }} (?)">
                             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
                         </button>
-                        <button onclick="toggleTheme()" class="icon-btn hidden md:inline-flex ml-2 print:hidden" aria-label="Toggle theme">
+                        <button onclick="toggleTheme()" class="icon-btn hidden md:inline-flex ml-2 print:hidden" aria-label="{{ tr.t("aria-toggle-theme") }}">
                             <svg class="hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
                                 <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"></path>
                             </svg>
@@ -304,7 +304,7 @@
                         </button>
                         <!-- Overflow menu for small screens -->
                         <div class="relative md:hidden ml-auto" id="more-menu-container">
-                            <button onclick="document.getElementById('more-dropdown').classList.toggle('hidden')" class="icon-btn" aria-label="More options">
+                            <button onclick="document.getElementById('more-dropdown').classList.toggle('hidden')" class="icon-btn" aria-label="{{ tr.t("aria-more-options") }}">
                                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"></path>
                                 </svg>
@@ -481,6 +481,7 @@
     <script>
         window.__PREFIX__ = {{ prefix|json|safe }};
         window.__STATIC_MODE__ = {{ static_mode|json|safe }};
+        window.__STRINGS__ = { close: {{ tr.t("aria-close")|json|safe }} };
     </script>
 
     <!-- Keyboard shortcuts -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -399,6 +399,10 @@
             });
         }
 
+        function escapeHtml(s) {
+            return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+        }
+
         searchInput.addEventListener('input', function() {
             clearTimeout(searchTimeout);
             const query = this.value.trim();
@@ -419,8 +423,8 @@
                         searchResults.innerHTML = '<div class="p-4 text-muted text-center">' + translations.noRecipes + '</div>';
                     } else {
                         searchResults.innerHTML = results.map(recipe =>
-                            `<a href="{{ prefix }}/recipe/${recipe.path}" class="search-result block px-4 py-3 hover:bg-sunk border-b border-line last:border-b-0">
-                                <div class="font-medium text-text">${recipe.name}</div>
+                            `<a href="{{ prefix }}/recipe/${escapeHtml(recipe.path)}" class="search-result block px-4 py-3 hover:bg-sunk border-b border-line last:border-b-0">
+                                <div class="font-medium text-text">${escapeHtml(recipe.name)}</div>
                             </a>`
                         ).join('');
                     }

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -201,9 +201,6 @@ document.addEventListener('keydown', function(e) {
     }
 });
 
-// Initial status
-updateSaveStatus('saved');
-
 // Delete modal functions
 function showDeleteModal() {
     const modal = document.getElementById('delete-modal');

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -43,7 +43,7 @@
                 <div class="flex items-center">
                     <label for="scale" class="text-sm font-medium text-muted mr-2">{{ tr.t("recipe-scale-label") }}:</label>
                     <div class="stepper">
-                        <button type="button" aria-label="Decrease scale" onclick="adjustScale(-0.5)">&minus;</button>
+                        <button type="button" aria-label="{{ tr.t("aria-decrease-scale") }}" onclick="adjustScale(-0.5)">&minus;</button>
                         <input type="number"
                                id="scale"
                                value="{{ scale }}"
@@ -51,7 +51,7 @@
                                max="200"
                                step="0.5"
                                onchange="goToScale(this.value)">
-                        <button type="button" aria-label="Increase scale" onclick="adjustScale(0.5)">+</button>
+                        <button type="button" aria-label="{{ tr.t("aria-increase-scale") }}" onclick="adjustScale(0.5)">+</button>
                     </div>
                 </div>
                 <a href="{{ prefix }}/edit/{{ recipe_path }}" class="btn" title="{{ tr.t("action-edit") }}">

--- a/templates/pantry.html
+++ b/templates/pantry.html
@@ -10,7 +10,7 @@
                 </svg>
             </div>
             <p id="pantry-error-message" class="flex-1 text-text text-sm font-mono whitespace-pre-wrap"></p>
-            <button type="button" onclick="document.getElementById('pantry-error-banner').classList.add('hidden')" class="icon-btn shrink-0" aria-label="Dismiss">
+            <button type="button" onclick="document.getElementById('pantry-error-banner').classList.add('hidden')" class="icon-btn shrink-0" aria-label="{{ tr.t("aria-dismiss") }}">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>

--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -44,7 +44,7 @@
                 <div class="flex items-center">
                     <label for="scale" class="text-sm font-medium text-muted mr-2">{{ tr.t("recipe-scale-label") }}:</label>
                     <div class="stepper">
-                        <button type="button" aria-label="Decrease scale" onclick="adjustScale(-0.5)">&minus;</button>
+                        <button type="button" aria-label="{{ tr.t("aria-decrease-scale") }}" onclick="adjustScale(-0.5)">&minus;</button>
                         <input type="number"
                                id="scale"
                                value="{{ scale }}"
@@ -52,7 +52,7 @@
                                max="200"
                                step="0.5"
                                onchange="goToScale(this.value)">
-                        <button type="button" aria-label="Increase scale" onclick="adjustScale(0.5)">+</button>
+                        <button type="button" aria-label="{{ tr.t("aria-increase-scale") }}" onclick="adjustScale(0.5)">+</button>
                     </div>
                 </div>
                 <a href="{{ prefix }}/edit/{{ recipe_path }}" class="btn" title="{{ tr.t("action-edit") }}">
@@ -422,7 +422,7 @@ function showRecipeError(message) {
                 </svg>
             </div>
             <p class="flex-1 text-text text-sm font-mono whitespace-pre-wrap"></p>
-            <button type="button" onclick="this.closest('#recipe-error-banner').remove()" class="icon-btn shrink-0" aria-label="Dismiss">
+            <button type="button" onclick="this.closest('#recipe-error-banner').remove()" class="icon-btn shrink-0" aria-label="{{ tr.t("aria-dismiss") }}">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>

--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -298,7 +298,7 @@
                 {% for section in sections %}
                 {% match section.name %}
                 {% when Some with (name) %}
-                <h3 class="text-title font-semibold mt-6 mb-4 text-accent-text border-b border-line pb-2">{{ name }}</h3>
+                <h2 class="text-title font-semibold mt-6 mb-4 text-accent-text border-b border-line pb-2">{{ name }}</h2>
                 {% when None %}
                 {% endmatch %}
                 <ol class="step-list space-y-4 {% if !loop.first %}mt-4{% endif %}">

--- a/templates/recipes.html
+++ b/templates/recipes.html
@@ -264,7 +264,12 @@
     });
 
     restore();
-    applySort();
+    // The server already renders name/asc (natural, case-folded), so on the
+    // default sort the DOM is left as served: no reorder on load, and names
+    // with accents keep the server's order instead of the collator's.
+    if (sortField !== 'name' || sortDir !== 'asc') {
+        applySort();
+    }
 })();
 </script>
 {% endblock %}

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -32,7 +32,7 @@
                 <div class="flex-1">
                     <p id="error-message" class="text-text text-sm font-mono whitespace-pre-wrap"></p>
                 </div>
-                <button type="button" onclick="hideError()" class="icon-btn shrink-0" aria-label="Dismiss">
+                <button type="button" onclick="hideError()" class="icon-btn shrink-0" aria-label="{{ tr.t("aria-dismiss") }}">
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                     </svg>

--- a/templates/shopping_list.html
+++ b/templates/shopping_list.html
@@ -286,7 +286,6 @@ async function clearList() {
         if (response.ok) {
             hideError();
             await loadShoppingList();
-            document.getElementById('shopping-list-results').classList.add('hidden');
         } else {
             const data = await response.json().catch(() => ({}));
             showError(data.error || 'Failed to clear list');
@@ -463,6 +462,9 @@ function displayShoppingList(data) {
 
     lastListData = data;
     updateCopyButtonVisibility();
+    // Live updates from another tab render here too, so make sure the
+    // container is showing whatever hid it earlier.
+    resultsDiv.classList.remove('hidden');
 
     let html = '';
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Seed directory used by the dev server started by Playwright's `webServer`.
+const SEED_DIR = path.resolve(__dirname, '../../seed');
+const RECIPE_FILE = path.join(SEED_DIR, 'Neapolitan Pizza.cook');
+
+test.describe('Recipe editor', () => {
+  test('does not autosave when the page is merely opened', async ({ page }) => {
+    const before = fs.statSync(RECIPE_FILE);
+    const originalContent = fs.readFileSync(RECIPE_FILE, 'utf8');
+
+    const saveRequests: string[] = [];
+    page.on('request', request => {
+      if (request.method() === 'PUT' && request.url().includes('/api/recipes/')) {
+        saveRequests.push(request.url());
+      }
+    });
+
+    await page.goto('/edit/Neapolitan Pizza.cook');
+    await page.waitForLoadState('networkidle');
+
+    // Wait past the autosave debounce so a spurious change would have fired.
+    await expect(page.locator('#editor-container .cm-editor')).toBeVisible();
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator('#save-status')).toHaveText('');
+    expect(saveRequests).toEqual([]);
+
+    const after = fs.statSync(RECIPE_FILE);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(fs.readFileSync(RECIPE_FILE, 'utf8')).toBe(originalContent);
+  });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -65,4 +65,27 @@ test.describe('Search Functionality', () => {
       await searchInput.clear();
     }
   });
+
+  test('should render inline result names as text, not markup', async ({ page }) => {
+    // Fabricate a result whose name is markup; a raw innerHTML interpolation
+    // would run the onerror handler and set the marker.
+    await page.route('**/api/search?*', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ path: 'x', name: '<img src=x onerror=window.__pwned=1>' }]),
+      })
+    );
+
+    const searchInput = page.getByPlaceholder('Search recipes...');
+    await searchInput.fill('pizza');
+
+    const result = page.locator('#search-results a.search-result');
+    await expect(result).toHaveCount(1);
+    await expect(result).toContainText('<img');
+    await expect(result.locator('img')).toHaveCount(0);
+
+    const pwned = await page.evaluate(() => (window as any).__pwned);
+    expect(pwned).toBeUndefined();
+  });
 });

--- a/tests/e2e/shopping-list.spec.ts
+++ b/tests/e2e/shopping-list.spec.ts
@@ -117,6 +117,24 @@ test.describe('Shopping List', () => {
     }
   });
 
+  test('should show the empty state after Clear All', async ({ page }) => {
+    // Add a known recipe so the list has something to clear
+    await helpers.navigateTo('/recipe/Breakfast/Easy Pancakes.cook');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: /Add to Shopping List/i }).click();
+    await page.waitForTimeout(500);
+
+    await helpers.goToShoppingList();
+    await expect(page.locator('#list-content li').first()).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /Clear All/i }).click();
+
+    // The results container must stay visible so the "no items" message shows
+    const results = page.locator('#shopping-list-results');
+    await expect(results).toBeVisible();
+    await expect(results.getByText(/No items in shopping list/i)).toBeVisible({ timeout: 5_000 });
+  });
+
   test('should aggregate duplicate ingredients', async ({ page }) => {
     // Add same recipe multiple times or scale it - use known recipe
     await helpers.navigateTo('/recipe/Breakfast/Easy Pancakes.cook');


### PR DESCRIPTION
Fixes the eight follow-ups listed in #456, one commit each.

- **#486** The recipes index is sorted naturally on the server (case-folded, digit runs by value), so the no-JS order matches what the browser produces. The client no longer re-sorts on load for the default sort, so there is no reorder on first paint. Accents are not folded server-side; that divergence is documented and pinned by a test.
- **#487** The server-mode search results escape recipe names and paths before insertion into `innerHTML`, matching `search.js`. A test injects a fabricated result and asserts nothing executes.
- **#488** Icon-button labels ("Toggle theme", "Dismiss", "Increase scale", …) come from eight new `aria-*` keys in all seven locales; the shortcuts modal reads its close label from `window.__STRINGS__`.
- **#489** Clear All no longer hides the shopping-list results container, so the empty state shows and live updates render into a visible element.
- **#490** Editor syntax colours are CSS classes on tokens (`.cm-cook-*` in `input.css`) instead of hex literals in `editor.js`, so they flip with the theme.
- **#491** The editor showed "Saved" on open because of an unconditional status call, not an autosave; the call is removed and a test asserts no PUT and an unchanged mtime.
- **#492** API docs endpoint summaries are `h3` and sectioned recipes' step headings are `h2`, so no page skips a heading level.
- **#493** The static-site build ships only compiled assets: `input.css`, `components.css` and `static/js/src/` are excluded.

## Verification

- `cargo fmt`, `cargo clippy --all-targets`, `cargo test` clean.
- Playwright (Chromium, serial): 146 passed, 5 pre-existing skips, 0 failed.
- Static build checked: 19 assets, no stylesheet sources.

## Filed while reviewing

- #494 multi-line block comments swallow the rest of the recipe in the editor.
- #495 quantities inside `{}` are not highlighted.

Closes #486, closes #487, closes #488, closes #489, closes #490, closes #491, closes #492, closes #493.

https://claude.ai/code/session_013urND2B6Y3Z7WQuDpE8ZDu
