### PR TITLE
docs: link the CookCLI documentation page from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/cooklang/CookCLI)](https://github.com/cooklang/CookCLI/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/cooklang/CookCLI?style=social)](https://github.com/cooklang/CookCLI)
 
-**Command line tools for working with [Cooklang](https://cooklang.org) recipes.**
+**Command line tools for working with [Cooklang](https://cooklang.org) recipes.** Full reference: [CookCLI documentation](https://cooklang.org/cli/).
 
 ### 🎯 Quick Install
 
@@ -621,6 +621,7 @@ Some source files include code from [cooklang-chef](https://github.com/Zheoni/co
 
 ## 🔗 Links
 
+* [CookCLI documentation](https://cooklang.org/cli/) - every command, the server, and guides
 * [Cooklang Specification](https://cooklang.org/docs/spec) - the recipe markup language
 * [Cooklang Apps](https://cooklang.org/app/) - iOS and Android apps
 


### PR DESCRIPTION
Adds https://cooklang.org/cli/ with the anchor "CookCLI documentation" under the tagline and as the first entry in Links. `cook --help` already points there (`after_help` in `src/args.rs`).

Why: the query "cookcli" ranks the GitHub repo on page 1 and cooklang.org/cli/ at ~16; on-site anchors didn't move it, so this is the backlink that matters (growth repo, `docs/2026-09-01-seo-priorities.md`, 2026-09-12 read, item E2).

https://claude.ai/code/session_01S7MfeikCzVYCNLEhpdAydt